### PR TITLE
Add event parsing from FB page and group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .eslintcache
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ If an event has multiple times/dates, it will have the `parentEvent` and `siblin
 ```javascript
 import {
   scrapeFbEventListFromPage,
-  scrapeFbEventListFromGroup
+  scrapeFbEventListFromProfile,
+  scrapeFbEventListFromGroup,
+  EventType
 } from 'facebook-event-scraper';
 
 // Scrape events from fb page

--- a/README.md
+++ b/README.md
@@ -118,6 +118,68 @@ The scrapeEvent function returns a Promise with the scraped event data. See belo
 
 If an event has multiple times/dates, it will have the `parentEvent` and `siblingEvents` fields populated. Each sibling event is a date for the parent event.
 
+## List events from FB Page or Group
+
+```javascript
+import {
+  scrapeFbEventListFromPage,
+  scrapeFbEventListFromGroup
+} from 'facebook-event-scraper';
+
+// Scrape events from fb page
+async function example() {
+  try {
+    const url = 'https://www.facebook.com/lacalle8prague/events';
+    const eventData = await scrapeFbEventListFromPage(url);
+    console.log(eventData);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+// Scrape events from fb group
+async function example2() {
+  try {
+    const url = 'https://www.facebook.com/groups/409785992417637/events';
+    const eventData2 = await scrapeFbEventListFromGroup(url);
+    console.log(eventData2);
+  } catch (err) {
+    console.error(err);
+  }
+}
+```
+
+Functions return a Promise with the list of scraped event data.
+
+```json
+[
+  {
+    "id": "916236709985575",
+    "name": "NEW YEAR EVE 2025",
+    "url": "https://www.facebook.com/events/916236709985575/",
+    "date": "Tue, Dec 31, 2024",
+    "isCanceled": false,
+    "isPast": true
+  },
+  {
+    "id": "591932410074832",
+    "name": "REGGAETON NIGHT",
+    "url": "https://www.facebook.com/events/591932410074832/",
+    "date": "Fri, Nov 22, 2024",
+    "isCanceled": false,
+    "isPast": true
+  },
+  {
+    "id": "1103230308135807",
+    "name": "FIESTA LATINA",
+    "url": "https://www.facebook.com/events/1103230308135807/",
+    "date": "Sat, Nov 9, 2024",
+    "isCanceled": false,
+    "isPast": true
+  }
+]
+```
+
 ### Using a proxy
 
 This library uses a GET request to fetch the Facebook event data. To use a proxy for this request, pass an object containing the proxy details as the second argument. The proxy data type is identical to the [Axios proxy options](https://axios-http.com/docs/req_config).

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import {
 async function example() {
   try {
     const url = 'https://www.facebook.com/lacalle8prague/events';
-    const eventData = await scrapeFbEventListFromPage(url);
+    const eventData = await scrapeFbEventListFromPage(url, EventType.Upcoming);
     console.log(eventData);
   } catch (err) {
     console.error(err);
@@ -141,7 +141,7 @@ async function example() {
 async function example2() {
   try {
     const url = 'https://www.facebook.com/groups/409785992417637/events';
-    const eventData2 = await scrapeFbEventListFromGroup(url);
+    const eventData2 = await scrapeFbEventListFromGroup(url, EventType.Past);
     console.log(eventData2);
   } catch (err) {
     console.error(err);

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ async function example2() {
     console.error(err);
   }
 }
+
+// Scrape events from fb user profile
+async function example3() {
+  try {
+    const url =
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events';
+    const eventData3 = await scrapeFbEventListFromProfile(url, EventType.Past);
+    console.log(eventData3);
+  } catch (err) {
+    console.error(err);
+  }
+}
 ```
 
 Functions return a Promise with the list of scraped event data.

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,5 @@
+/* eslint-disable no-shadow */
+export enum EventType {
+  Upcoming,
+  Past
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,3 +49,15 @@ export const scrapeFbEventListFromGroup = async (
 
   return eventListParser.getEventListFromGroup(dataString, type);
 };
+
+export const scrapeFbEventList = async (
+  url: string,
+  type?: EventType,
+  options: ScrapeOptions = {}
+): Promise<ShortEventData[]> => {
+  if (url.includes('/groups/')) {
+    return scrapeFbEventListFromGroup(url, type, options);
+  } 
+    return scrapeFbEventListFromPage(url, type, options);
+  
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
-import { validateAndFormatUrl, fbidToUrl } from './utils/url';
-import { EventData, ScrapeOptions } from './types';
+import {
+  fbidToUrl,
+  validateAndFormatEventGroupUrl,
+  validateAndFormatEventPageUrl,
+  validateAndFormatUrl
+} from './utils/url';
+import { EventData, ScrapeOptions, ShortEventData } from './types';
+import * as eventListParser from './utils/eventListParser';
 import { scrapeEvent } from './scraper';
+import { fetchEvent } from './utils/network';
+import { EventType } from './enums';
 
-export { EventData, ScrapeOptions };
+export { EventData, ScrapeOptions, ShortEventData, EventType };
 
 export const scrapeFbEvent = async (
   url: string,
@@ -18,4 +26,26 @@ export const scrapeFbEventFromFbid = async (
 ): Promise<EventData> => {
   const formattedUrl = fbidToUrl(fbid);
   return await scrapeEvent(formattedUrl, options);
+};
+
+export const scrapeFbEventListFromPage = async (
+  url: string,
+  options: ScrapeOptions = {},
+  type?: EventType
+): Promise<ShortEventData[]> => {
+  const formattedUrl = validateAndFormatEventPageUrl(url, type);
+  const dataString = await fetchEvent(formattedUrl, options.proxy);
+
+  return eventListParser.getEventListFromPage(dataString);
+};
+
+export const scrapeFbEventListFromGroup = async (
+  url: string,
+  type?: EventType,
+  options: ScrapeOptions = {}
+): Promise<ShortEventData[]> => {
+  const formattedUrl = validateAndFormatEventGroupUrl(url);
+  const dataString = await fetchEvent(formattedUrl, options.proxy);
+
+  return eventListParser.getEventListFromGroup(dataString, type);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ export const scrapeFbEventFromFbid = async (
 
 export const scrapeFbEventListFromPage = async (
   url: string,
-  options: ScrapeOptions = {},
-  type?: EventType
+  type?: EventType,
+  options: ScrapeOptions = {}
 ): Promise<ShortEventData[]> => {
   const formattedUrl = validateAndFormatEventPageUrl(url, type);
   const dataString = await fetchEvent(formattedUrl, options.proxy);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   fbidToUrl,
   validateAndFormatEventGroupUrl,
   validateAndFormatEventPageUrl,
+  validateAndFormatEventProfileUrl,
   validateAndFormatUrl
 } from './utils/url';
 import { EventData, ScrapeOptions, ShortEventData } from './types';
@@ -36,7 +37,18 @@ export const scrapeFbEventListFromPage = async (
   const formattedUrl = validateAndFormatEventPageUrl(url, type);
   const dataString = await fetchEvent(formattedUrl, options.proxy);
 
-  return eventListParser.getEventListFromPage(dataString);
+  return eventListParser.getEventListFromPageOrProfile(dataString);
+};
+
+export const scrapeFbEventListFromProfile = async (
+  url: string,
+  type?: EventType,
+  options: ScrapeOptions = {}
+): Promise<ShortEventData[]> => {
+  const formattedUrl = validateAndFormatEventProfileUrl(url, type);
+  const dataString = await fetchEvent(formattedUrl, options.proxy);
+
+  return eventListParser.getEventListFromPageOrProfile(dataString);
 };
 
 export const scrapeFbEventListFromGroup = async (
@@ -57,7 +69,8 @@ export const scrapeFbEventList = async (
 ): Promise<ShortEventData[]> => {
   if (url.includes('/groups/')) {
     return scrapeFbEventListFromGroup(url, type, options);
-  } 
-    return scrapeFbEventListFromPage(url, type, options);
-  
+  } if (url.includes('/profile.php')) {
+    return scrapeFbEventListFromProfile(url, type, options);
+  }
+  return scrapeFbEventListFromPage(url, type, options);
 };

--- a/src/tests/__snapshots__/e2e.test.ts.snap
+++ b/src/tests/__snapshots__/e2e.test.ts.snap
@@ -11,7 +11,7 @@ exports[`E2E Generates the correct event data for a Messenger Rooms Online event
       "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
       "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
@@ -79,7 +79,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100068207392255",
       "name": "Scotiabank Saddledome",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/281352750_2028415974017689_9212573442765953743_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=CUtBHBcSvkwQ7kNvgF1RzCF&_nc_oc=Adl0ekulQycJe3WNVmDmyru0Sa0najIK73ywHl7AgZBJT96yEC48Gdp3b5uJm4-wHg5w8voww2SucrbtdpG-4tkI&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYFSk_RvaMxBVGmRk4I-e7zJFSr3Ccneh1w4Wj29Gi2hVg&oe=67F47DCB",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/281352750_2028415974017689_9212573442765953743_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=CUtBHBcSvkwQ7kNvgF1RzCF&_nc_oc=Adl0ekulQycJe3WNVmDmyru0Sa0najIK73ywHl7AgZBJT96yEC48Gdp3b5uJm4-wHg5w8voww2SucrbtdpG-4tkI&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=5P7CgIOFVouAKXTlv7Xodw&oh=00_AYFxt5x7BsTKxlAD6vqtfGb7nKluNuzDS1qCxfpcsOm2CA&oe=67F47DCB",
       },
       "type": "User",
       "url": "https://www.facebook.com/scotiabanksaddledome",
@@ -88,7 +88,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100064516969267",
       "name": "Calgary Stampede",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/352087888_1034380311273324_7910170983351471836_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=lBA4W9u9D90Q7kNvgGcwYHA&_nc_oc=AdkiOqEJDmcUnPD_t5H0YrNwVcKS-SdQzNd09juXIGMmIR0TzHkY5xtrUdsTxlBmDjklitFWU1aLWEilA4W6zUUg&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYHSvu3-N10ju6FWOWe2sv00GNUsx6qe93c9-qRZE9nnmw&oe=67F4622B",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/352087888_1034380311273324_7910170983351471836_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=lBA4W9u9D90Q7kNvgGcwYHA&_nc_oc=AdkiOqEJDmcUnPD_t5H0YrNwVcKS-SdQzNd09juXIGMmIR0TzHkY5xtrUdsTxlBmDjklitFWU1aLWEilA4W6zUUg&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=5P7CgIOFVouAKXTlv7Xodw&oh=00_AYFaccO3pTpLR7ZtiGwGqYUtJhwbezsRflWZlmY5d4ZWwg&oe=67F4622B",
       },
       "type": "User",
       "url": "https://www.facebook.com/calgarystampede",
@@ -97,7 +97,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100063699336240",
       "name": "Stampede Ent. Inc.",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYF6m8bJUe1hod0a7Y_YyFj8Lz0XA1n3Kofxyf7OCn1iRA&oe=67F48282",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=5P7CgIOFVouAKXTlv7Xodw&oh=00_AYE6tOvevTmOCpAZXi3Mrgw8gJz8Ktc9XTgU8QAYj5psrA&oe=67F48282",
       },
       "type": "User",
       "url": "https://www.facebook.com/StampedeEntInc",
@@ -106,7 +106,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100044535845092",
       "name": "Pitbull",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/439064200_1017561226405063_8213471074013536032_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=9uxGoyxnuAQQ7kNvgFlLc-P&_nc_oc=AdkZ2n5OkCQoxBZc1BkJFt6xiJIKx-sf8cJtyciHJI9jRBgYFk2Eo89L86KBjsGZ99lXFwZRamwpBxGuTSN2mgM0&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYERx3dl6q8Jc5RHQ_Tk2hmYudds1yeiZPB3ik6O_544wg&oe=67F46183",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/439064200_1017561226405063_8213471074013536032_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=1&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=9uxGoyxnuAQQ7kNvgFlLc-P&_nc_oc=AdkZ2n5OkCQoxBZc1BkJFt6xiJIKx-sf8cJtyciHJI9jRBgYFk2Eo89L86KBjsGZ99lXFwZRamwpBxGuTSN2mgM0&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=5P7CgIOFVouAKXTlv7Xodw&oh=00_AYFw9lNVxkfqLEdOHiopLt8RVDutyZNHUwpqjsaXVe4wOg&oe=67F46183",
       },
       "type": "User",
       "url": "https://www.facebook.com/pitbull",
@@ -136,7 +136,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
   "parentEvent": null,
   "photo": {
     "id": "10160954790708641",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/336792249_949153626262984_8332769163095794984_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=hhcKOPPcsXsQ7kNvgE7mcQ2&_nc_oc=AdmOYnx2JxZ7ct4ex77OUBfcvVv68EWIen3YbOI8hM4mSzzntG0S9LTPFHBJY7VnGrmYCnfdnh9TZzYvIxtbC2fo&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=tt8QbVfBQaUYzXL2E0cfow&oh=00_AYFsctAcPCjbzFotmnH9nhriuDoNhS6dmSmTxGrmxAR3Ig&oe=67F45C6D",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/336792249_949153626262984_8332769163095794984_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=hhcKOPPcsXsQ7kNvgE7mcQ2&_nc_oc=AdmOYnx2JxZ7ct4ex77OUBfcvVv68EWIen3YbOI8hM4mSzzntG0S9LTPFHBJY7VnGrmYCnfdnh9TZzYvIxtbC2fo&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=LY0nrwRvsWveqiWQdrnseg&oh=00_AYH-Wi1SZSs817gxts-nJI6UMjSkhyPDJ4hWfnzf_eJhFw&oe=67F45C6D",
     "url": "https://www.facebook.com/photo/?fbid=10160954790708641&set=gm.602005851971871",
   },
   "siblingEvents": [],
@@ -175,7 +175,7 @@ More info: https://www.faccalgary.com/easter",
       "id": "100064691376556",
       "name": "FAC Deerfoot",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/460987627_944177641081940_5270929113802053218_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=6_4Ericq7OgQ7kNvgGqhW4Y&_nc_oc=AdmHaK1dalJDU__V24mCbetJykOvNixK1iPNkh29O1M1INR_auEeuVQSyr66WVJ7RC27jnvjT7W5mc2VYoT-m3Y2&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yinho4me4PVgi2KmpMJg3Q&oh=00_AYGHxN7iXBkJAtmNaYuh45EqM-j4qn_oLXXPrD-pXK9c4g&oe=67F454E4",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/460987627_944177641081940_5270929113802053218_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=6_4Ericq7OgQ7kNvgGqhW4Y&_nc_oc=AdmHaK1dalJDU__V24mCbetJykOvNixK1iPNkh29O1M1INR_auEeuVQSyr66WVJ7RC27jnvjT7W5mc2VYoT-m3Y2&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=7wvJMmgj8D18hgmgKPK9AA&oh=00_AYHGlDMTBgu-rFCdSCMkGbpbWQu0OHKARuuHNjx0GSqWbg&oe=67F48D24",
       },
       "type": "User",
       "url": "https://www.facebook.com/facdeerfoot",
@@ -208,7 +208,7 @@ Official Facebook Page for First Alliance Church",
   },
   "photo": {
     "id": "595982989234742",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/481055432_1056019033231133_4786716278309143615_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=Fnd3Pv_xvy0Q7kNvgGg5luk&_nc_oc=AdkWORkOMTHv7RL_P_3dJBB6vW-GWAMEBFN3mqumLGepJauPSPR54iT-8BLKIsFQ9R_P36Wl6M0V0qlUphacvUZ2&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=2wFLk5_yjAfg-veaJQQ2zg&oh=00_AYHDfoWp10NWIqwUK-vwWXp1sfyjS6UfKz0Fi86ceg3hWw&oe=67F46914",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/481055432_1056019033231133_4786716278309143615_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=Fnd3Pv_xvy0Q7kNvgGg5luk&_nc_oc=AdkWORkOMTHv7RL_P_3dJBB6vW-GWAMEBFN3mqumLGepJauPSPR54iT-8BLKIsFQ9R_P36Wl6M0V0qlUphacvUZ2&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=uTSXNBP6Y654ImzyeR0N1A&oh=00_AYEy5pDrdujXY5kdkoXGMdTTz8GoXLwad7zwR0eZkeU2Dw&oe=67F46914",
     "url": "https://www.facebook.com/photo/?fbid=595982989234742&set=gm.1137956736879596",
   },
   "siblingEvents": [
@@ -284,7 +284,7 @@ Binoculars are available to borrow for those who need them.",
   "parentEvent": null,
   "photo": {
     "id": "10167524860335261",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/337885002_189168827241357_2737797815564835189_n.jpg?stp=dst-jpg_p960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=75d36f&_nc_ohc=N2sp8WNyvXAQ7kNvgHMlq_b&_nc_oc=AdmAr5X1VdZexCPMuultzHDJVq5zGuS005WCjDU5WZgQkhpxOxWZrKo_YMt9_rjduXoPKGUdXdflF2EbZKRP8nA3&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=FyOdqNaHMV_bkl44Y2ZBHQ&oh=00_AYGnUUHV7eRPt2nxIR2U3ZgO_veZtQkb_wKSwhYFc9AWNA&oe=67F45CB1",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/337885002_189168827241357_2737797815564835189_n.jpg?stp=dst-jpg_p960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=75d36f&_nc_ohc=N2sp8WNyvXAQ7kNvgHMlq_b&_nc_oc=AdmAr5X1VdZexCPMuultzHDJVq5zGuS005WCjDU5WZgQkhpxOxWZrKo_YMt9_rjduXoPKGUdXdflF2EbZKRP8nA3&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=ExacUxm76mc4Ps3NrdwM9w&oh=00_AYGMljshC742M9mFZ6CZukNd3X1cDJKPtGJ3mE4O2rqyPQ&oe=67F45CB1",
     "url": "https://www.facebook.com/photo/?fbid=10167524860335261&set=gm.252144523936238",
   },
   "siblingEvents": [],
@@ -317,7 +317,7 @@ At the Lilac Festival, there is an activity made for all ages. This could mean a
       "id": "100050510798749",
       "name": "Lilac Festival",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/343412725_1217737712204297_6274770509266232269_n.jpg?stp=c50.34.938.938a_cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=DRc_Hf0Z5u4Q7kNvgGVIYeX&_nc_oc=Adld_eWoI06jV8rI9A0Et0pYe6kB8h_nxfNr93hdKTmsCqidhxKYtnEcfEd0a6dZr1B34NJaDwsdY4xAQsnzK-rJ&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=mHA9NBDdpIChH2OLGWn-eA&oh=00_AYEvcocCQx7GHZCyQf8v9ZZ0jOLdAPcGThGWeFh_vSrUOg&oe=67F47DF4",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/343412725_1217737712204297_6274770509266232269_n.jpg?stp=c50.34.938.938a_cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=DRc_Hf0Z5u4Q7kNvgGVIYeX&_nc_oc=Adld_eWoI06jV8rI9A0Et0pYe6kB8h_nxfNr93hdKTmsCqidhxKYtnEcfEd0a6dZr1B34NJaDwsdY4xAQsnzK-rJ&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=Vs5pt1hBn9NFPWk5_cLoMQ&oh=00_AYHaeZluBwlJv1McCAvmQE6FLVfpt1PApVPvIWKm8ancyg&oe=67F47DF4",
       },
       "type": "User",
       "url": "https://www.facebook.com/LilacFestival",
@@ -344,7 +344,7 @@ At the Lilac Festival, there is an activity made for all ages. This could mean a
   "parentEvent": null,
   "photo": {
     "id": "749222690104751",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/472570967_1152279459799070_954455182245359149_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=CuHA6jyZQOYQ7kNvgG3WefK&_nc_oc=AdkYlKkXZKVlI6XtBW210Ui-mdm9YUTeuiJK9ek4YOjmeLVhl_VLCZL6-WfRew9DVQdALjpnAsYwt_yhevpR_y4e&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=H8ueXL59YU6lgmaD69Tdog&oh=00_AYGOuBrvrPwHCjNMKvEniyXe1HOBeIcKI9DW9STTzU2osw&oe=67F47654",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/472570967_1152279459799070_954455182245359149_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=CuHA6jyZQOYQ7kNvgG3WefK&_nc_oc=AdkYlKkXZKVlI6XtBW210Ui-mdm9YUTeuiJK9ek4YOjmeLVhl_VLCZL6-WfRew9DVQdALjpnAsYwt_yhevpR_y4e&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=LApHZewGM6znEXKmfwJlUA&oh=00_AYH_X_oBRmBr4wKSApQQWn2TJFb_ppkbiBEICIMOC7FW-w&oe=67F47654",
     "url": "https://www.facebook.com/photo/?fbid=749222690104751&set=gm.719931573255940",
   },
   "siblingEvents": [],
@@ -368,7 +368,7 @@ exports[`E2E Generates the correct event data for an event with a text location 
       "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
       "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
@@ -440,7 +440,7 @@ https://www.facebook.com/groups/darkeighties
       "id": "100070821304084",
       "name": "12XU",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/410227062_382882167415824_4051646999230968301_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3fhOL_F0BJYQ7kNvgGFmOkv&_nc_oc=AdmGr9PFwuYsbRfWJkTeEPUmhLWl3te9fSgc8WxMvXqiyG0bPvQ6kbhes3ekIsTB8IRClGE2WmWRBhWEySccc56j&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=8B--XKVD5GWcuUoEJR9IAQ&oh=00_AYGrb7evBBcbLe-8ytVsQYrgmTAWKZgjuO9mvFXwXxdMnA&oe=67F478A6",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/410227062_382882167415824_4051646999230968301_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3fhOL_F0BJYQ7kNvgGFmOkv&_nc_oc=AdmGr9PFwuYsbRfWJkTeEPUmhLWl3te9fSgc8WxMvXqiyG0bPvQ6kbhes3ekIsTB8IRClGE2WmWRBhWEySccc56j&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=Y5aloaM0SgBgmwRdPYueow&oh=00_AYHreST7mVUvKflwE91Vd89bI7fYMbzhWZTOaRytjaTq2Q&oe=67F478A6",
       },
       "type": "User",
       "url": "https://www.facebook.com/12XUevents",
@@ -449,7 +449,7 @@ https://www.facebook.com/groups/darkeighties
       "id": "100063904024919",
       "name": "The Dark Eighties",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/332078465_858485495251843_6558149897498817316_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=AU3vP_vEWoYQ7kNvgFfbdrE&_nc_oc=AdnpGa_aIJBpp_5P9HXUcy8YjuUfpSlzDs0Op80FC9PBrASOnAPDtIgIEuU6XwDaIxEvE9z6EeKxNOh0Sm9AkaVl&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=8B--XKVD5GWcuUoEJR9IAQ&oh=00_AYGpQYzRe1-53QnGVUkmRN06FqYiB6b32zo7I6u2GhlCIg&oe=67F48827",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/332078465_858485495251843_6558149897498817316_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=AU3vP_vEWoYQ7kNvgFfbdrE&_nc_oc=AdnpGa_aIJBpp_5P9HXUcy8YjuUfpSlzDs0Op80FC9PBrASOnAPDtIgIEuU6XwDaIxEvE9z6EeKxNOh0Sm9AkaVl&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=Y5aloaM0SgBgmwRdPYueow&oh=00_AYHNpN4AoEdEIWU7mcmSwVv8OrfqubBJK7mtSCMOacc5ng&oe=67F48827",
       },
       "type": "User",
       "url": null,
@@ -476,7 +476,7 @@ https://www.facebook.com/groups/darkeighties
   "parentEvent": null,
   "photo": {
     "id": "621131586693637",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/483866251_1107783254695132_4478007887358984133_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=75d36f&_nc_ohc=2Zp--_qQUi0Q7kNvgHOdgXt&_nc_oc=AdkhayeOn4jVq8bkbP2mJzcz1i9VF3Er2to2JD2fdFSvp8dd_Mndw-drrxhYhgj5qOLWJZ2L83iyuS_M_uRDtjjd&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=t1Mfn3MpTsm5ylm6JUvdOw&oh=00_AYH8s6fO-5R6jFV4kJICfD8Br91r80EYCT3GEvv3EV-oJA&oe=67F464E8",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/483866251_1107783254695132_4478007887358984133_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=75d36f&_nc_ohc=2Zp--_qQUi0Q7kNvgHOdgXt&_nc_oc=AdkhayeOn4jVq8bkbP2mJzcz1i9VF3Er2to2JD2fdFSvp8dd_Mndw-drrxhYhgj5qOLWJZ2L83iyuS_M_uRDtjjd&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=FdhfKBmsxVd7nGcHmlfGng&oh=00_AYGQZlhXRSf7ENlK7clkT5tezhJlNWXtTo8dI44FdxBkGQ&oe=67F464E8",
     "url": "https://www.facebook.com/photo/?fbid=621131586693637&set=gm.1376686326480508",
   },
   "siblingEvents": [],
@@ -490,6 +490,50 @@ https://www.facebook.com/groups/darkeighties
 `;
 
 exports[`E2E Generates the correct event data for an event with a video cover 1`] = `
+{
+  "categories": [],
+  "description": "hbhjbjh",
+  "endTimestamp": null,
+  "formattedDate": "Tuesday, April 4, 2023 at 11:00 PM MDT",
+  "hosts": [
+    {
+      "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
+      "name": "Joe Smith",
+      "photo": {
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
+      },
+      "type": "User",
+      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
+    },
+  ],
+  "id": "526262926343074",
+  "isOnline": false,
+  "location": {
+    "address": null,
+    "city": null,
+    "coordinates": null,
+    "countryCode": null,
+    "description": null,
+    "id": "1260045608271508",
+    "name": "kbhbj",
+    "type": "TEXT",
+    "url": null,
+  },
+  "name": "Event to test",
+  "onlineDetails": null,
+  "parentEvent": null,
+  "photo": null,
+  "siblingEvents": [],
+  "startTimestamp": 1680670800,
+  "ticketUrl": null,
+  "timezone": "UTC-06",
+  "url": "https://www.facebook.com/events/526262926343074/",
+  "usersResponded": 1,
+  "video": null,
+}
+`;
+
+exports[`E2E Generates the correct event data for an event with a video cover 2`] = `
 {
   "categories": [
     {
@@ -516,7 +560,7 @@ Ateitį kurkime šiandien!
       "id": "100067786593384",
       "name": "Lietuva 2050",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/353748572_586062753663273_3803358940549831479_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=PwodFXL7tpkQ7kNvgGbdk3H&_nc_oc=Adl868_fFe1vsu6QcDRPtXfXx6VoqyE1httXOgAeLuWuIIqaJSqJdEPMAMioca7vFeYQf2il6bZyF5gFKUrdhoU9&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYGdsNwuIYNE8dimQBAfYzuKhpTW-qFQC5v3Q71LmoiPYg&oe=67F453D1",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/353748572_586062753663273_3803358940549831479_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=PwodFXL7tpkQ7kNvgGbdk3H&_nc_oc=Adl868_fFe1vsu6QcDRPtXfXx6VoqyE1httXOgAeLuWuIIqaJSqJdEPMAMioca7vFeYQf2il6bZyF5gFKUrdhoU9&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=kAWxe11J1r73haQSHLVyIQ&oh=00_AYE-BHjXW59dGzyQYp-yfliHu6k9H0IJdfyeyP1Gq1eAtw&oe=67F48C11",
       },
       "type": "User",
       "url": "https://www.facebook.com/Lietuva2050",
@@ -525,7 +569,7 @@ Ateitį kurkime šiandien!
       "id": "100039182298687",
       "name": "VU Šiaulių akademija",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274600858_487344632966234_2522454326585058130_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=105&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=-fbd_Gl1fikQ7kNvgFg7SMJ&_nc_oc=AdmC9KEhzYbR1sPPGHY858pYGhqog_m_zUHTXVTSgaGq1D1d23UWwBHIjiPKc-2ZtfrJB1p8teHWKRqMuGBANFE_&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYH4q34nYdwbZYy9dLIEv5iXxroF1FDF9yusovwe7nVreQ&oe=67F4773C",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274600858_487344632966234_2522454326585058130_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=105&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=-fbd_Gl1fikQ7kNvgFg7SMJ&_nc_oc=AdmC9KEhzYbR1sPPGHY858pYGhqog_m_zUHTXVTSgaGq1D1d23UWwBHIjiPKc-2ZtfrJB1p8teHWKRqMuGBANFE_&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=kAWxe11J1r73haQSHLVyIQ&oh=00_AYH8Sm7-uuWA6kiLfQNLuq67u5GhrZe6PBn6XpoL4ix42g&oe=67F4773C",
       },
       "type": "User",
       "url": "https://www.facebook.com/siauliu.akademija",
@@ -534,7 +578,7 @@ Ateitį kurkime šiandien!
       "id": "100064306435250",
       "name": "Vilniaus universitetas / Vilnius University",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274532730_5225887714128805_1147028878997655106_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=04xDEPunUMEQ7kNvgErtHIq&_nc_oc=Adn59tBFlUv3veeZv1EhFRvjsaC2azhK93ZA5rClWFF6bw9soWp9f7DErp8qNe4_bWRk6VNwSbWqtuEu5XFeSlhH&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYGK1jbOls3X6CTMIOfm5UOFNwNS_CaBzz0f9koD-XCdIg&oe=67F45D72",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274532730_5225887714128805_1147028878997655106_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=04xDEPunUMEQ7kNvgErtHIq&_nc_oc=Adn59tBFlUv3veeZv1EhFRvjsaC2azhK93ZA5rClWFF6bw9soWp9f7DErp8qNe4_bWRk6VNwSbWqtuEu5XFeSlhH&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=kAWxe11J1r73haQSHLVyIQ&oh=00_AYF_fKp81OIJTWvAWz_aSsC75xjiUb4K-bqVN-sGVvhNSg&oe=67F45D72",
       },
       "type": "User",
       "url": "https://www.facebook.com/VilniusUniversity",
@@ -543,7 +587,7 @@ Ateitį kurkime šiandien!
       "id": "100064644461523",
       "name": "Šiaulių apskrities Povilo Višinskio viešoji biblioteka",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/473965764_1047560367408769_1188670290210731717_n.jpg?stp=c293.0.1414.1414a_cp0_dst-jpg_s74x74_tt6&_nc_cat=100&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=WuGDGugjHCQQ7kNvgGIRJKz&_nc_oc=AdncOdOujimgATfzouuTFxiU4rmwIUs0WWEAXplUOppk2tDHYl-Ax1pX1B94XATkT2WKaKJqwmkPzaf5qGk0SEcC&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYHtfm5kxU9maudZjLY2n0RMDmaZwLJgVX6hAqs_b60bfg&oe=67F463FA",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/473965764_1047560367408769_1188670290210731717_n.jpg?stp=c293.0.1414.1414a_cp0_dst-jpg_s74x74_tt6&_nc_cat=100&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=WuGDGugjHCQQ7kNvgGIRJKz&_nc_oc=AdncOdOujimgATfzouuTFxiU4rmwIUs0WWEAXplUOppk2tDHYl-Ax1pX1B94XATkT2WKaKJqwmkPzaf5qGk0SEcC&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=kAWxe11J1r73haQSHLVyIQ&oh=00_AYGM_yuni8ExmCVzRvUANzIDYm25rmDS5n4i077t7U0nug&oe=67F463FA",
       },
       "type": "User",
       "url": "https://www.facebook.com/SAVB.info",
@@ -567,7 +611,7 @@ Ateitį kurkime šiandien!
   "usersResponded": 123,
   "video": {
     "id": "2194658774256880",
-    "thumbnailUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t15.5256-10/343286097_763205485254382_1688962917143675368_n.jpg?stp=dst-jpg_s960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=282d23&_nc_ohc=-VXX72wKevMQ7kNvgES91oA&_nc_oc=AdkpDqP7104s1DXZLqFyW09SduLJgkEHzOdbTmu_eZElfn--VtZ4-xMHrruD4CgpODsB3FOR43QR_4D7iRAZgGfq&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=hpvG5SAj0CzYErSVWx0fag&oh=00_AYEJtKos0GVydlcNv2TlTnZmmST3ZB7DiuBV-ndXcHDDng&oe=67F46A2B",
+    "thumbnailUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t15.5256-10/343286097_763205485254382_1688962917143675368_n.jpg?stp=dst-jpg_s960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=282d23&_nc_ohc=-VXX72wKevMQ7kNvgES91oA&_nc_oc=AdkpDqP7104s1DXZLqFyW09SduLJgkEHzOdbTmu_eZElfn--VtZ4-xMHrruD4CgpODsB3FOR43QR_4D7iRAZgGfq&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=UiMIBweKcQLnTaKKTAvSgQ&oh=00_AYFbE-sPjVQ_OXFD8Keh-mcTGRXSYd-nbqnQmyq3_LPZ7Q&oe=67F46A2B",
     "url": "https://www.facebook.com/Lietuva2050/videos/2194658774256880/",
   },
 }
@@ -591,7 +635,7 @@ Tickets are ON SALE NOW!",
       "id": "100064709654009",
       "name": "All Elite Wrestling",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/448627833_865600602273587_4050110030248245393_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=8KTjVe07mKUQ7kNvgEXUzG-&_nc_oc=Adk7x075UR7_4rekBgjetdyJjOqVehwE6lNfqmWmD0229WiecWOiQThNFQ0pL8Nb2WsDDvyI6rHqf-gHF25WMwXX&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=nPjsuGgp63cBsUmG3DONGg&oh=00_AYFa3vxTCSxHi5N4GusXoItKQh2XQnqpSN3SUrRxsGyTkg&oe=67F46A69",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/448627833_865600602273587_4050110030248245393_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=1&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=8KTjVe07mKUQ7kNvgEXUzG-&_nc_oc=Adk7x075UR7_4rekBgjetdyJjOqVehwE6lNfqmWmD0229WiecWOiQThNFQ0pL8Nb2WsDDvyI6rHqf-gHF25WMwXX&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=MTBYkrdChY1BAEG8xRYfVg&oh=00_AYEJb-P5O7GYZk4r17wG1OTq9kbU6CLivp49Xt9JNN-_TQ&oe=67F46A69",
       },
       "type": "User",
       "url": "https://www.facebook.com/AEW",
@@ -600,7 +644,7 @@ Tickets are ON SALE NOW!",
       "id": "100063699336240",
       "name": "Stampede Ent. Inc.",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=nPjsuGgp63cBsUmG3DONGg&oh=00_AYGaYm5uUBqNxEKDb2CG7p80Kv7KQI1rmyKs2Os05kC1TA&oe=67F48282",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=MTBYkrdChY1BAEG8xRYfVg&oh=00_AYFD7pO974B5mFCC3YkJLAS4IjRWq0nOLjlFSz2k4EZV1g&oe=67F48282",
       },
       "type": "User",
       "url": "https://www.facebook.com/StampedeEntInc",
@@ -630,7 +674,7 @@ Tickets are ON SALE NOW!",
   "parentEvent": null,
   "photo": {
     "id": "1273089803342464",
-    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/473081369_1630277110957063_1481524804345515679_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=LT3de8An608Q7kNvgGwzhoB&_nc_oc=AdnvoqwE6-6azAFH06hLCkJPXesvKfQj8kXamNBTJJFC0cJteHGTjqvRM483RtjmFaIs3dw3YsU1G3CwuIufzNhy&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=e7R2_1Ufi3Lc9pvD12jrPQ&oh=00_AYHBEQCGUbojTJn5IF_jLz8pcfJtTye4Z0p4i9hl-9A-Zg&oe=67F482F6",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/473081369_1630277110957063_1481524804345515679_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=LT3de8An608Q7kNvgGwzhoB&_nc_oc=AdnvoqwE6-6azAFH06hLCkJPXesvKfQj8kXamNBTJJFC0cJteHGTjqvRM483RtjmFaIs3dw3YsU1G3CwuIufzNhy&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=8o6kO-0t9LYhZw0pLD22Mw&oh=00_AYFr_BDdubab2_zASo-Afy14W0eZ7INerYfT_4CPMsWN1g&oe=67F482F6",
     "url": "https://www.facebook.com/photo/?fbid=1273089803342464&set=gm.977705193657933",
   },
   "siblingEvents": [],
@@ -654,7 +698,7 @@ exports[`E2E Generates the correct event data for an online event with a third-p
       "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
       "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
@@ -678,4 +722,103 @@ exports[`E2E Generates the correct event data for an online event with a third-p
   "usersResponded": 1,
   "video": null,
 }
+`;
+
+exports[`E2E Generates the correct event data for events from group 1`] = `[]`;
+
+exports[`E2E Generates the correct event data for events from group page 1`] = `[]`;
+
+exports[`E2E Generates the correct event data for past events from page 1`] = `
+[
+  {
+    "date": "Tue, Apr 1",
+    "id": "1372327683701218",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/1372327683701218/",
+  },
+  {
+    "date": "Tue, Mar 25",
+    "id": "1369200957569262",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/1369200957569262/",
+  },
+  {
+    "date": "Tue, Mar 18",
+    "id": "998491512228665",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/998491512228665/",
+  },
+  {
+    "date": "Tue, Mar 11",
+    "id": "1739191463661568",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/1739191463661568/",
+  },
+  {
+    "date": "Tue, Mar 4",
+    "id": "567208933022674",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "Bachata & Salsa - FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/567208933022674/",
+  },
+  {
+    "date": "Tue, Feb 25",
+    "id": "1298022051410475",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "BACHATA & SALSA FIESTA - Free Entry",
+    "url": "https://www.facebook.com/events/1298022051410475/",
+  },
+  {
+    "date": "Tue, Feb 18",
+    "id": "1179327486959175",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "BACHATA & SALSA FIESTA - Free Entry",
+    "url": "https://www.facebook.com/events/1179327486959175/",
+  },
+  {
+    "date": "Tue, Feb 11",
+    "id": "1026039145985800",
+    "isCanceled": false,
+    "isPast": true,
+    "name": "BACHATA & SALSA FIESTA - Free Entry",
+    "url": "https://www.facebook.com/events/1026039145985800/",
+  },
+]
+`;
+
+exports[`E2E Generates the correct event data for upcoming events from page 1`] = `
+[
+  {
+    "date": "Thu, Apr 3 at 8:00 PM CEST",
+    "id": "1148340996977550",
+    "isCanceled": false,
+    "isPast": false,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/1148340996977550/",
+  },
+]
+`;
+
+exports[`E2E Generates the correct event data for upcoming events from page 2`] = `
+[
+  {
+    "date": "Thu, Apr 3 at 8:00 PM CEST",
+    "id": "1148340996977550",
+    "isCanceled": false,
+    "isPast": false,
+    "name": "Bachata & Salsa: FREE Open Class + Party",
+    "url": "https://www.facebook.com/events/1148340996977550/",
+  },
+]
 `;

--- a/src/tests/__snapshots__/e2e.test.ts.snap
+++ b/src/tests/__snapshots__/e2e.test.ts.snap
@@ -8,13 +8,13 @@ exports[`E2E Generates the correct event data for a Messenger Rooms Online event
   "formattedDate": "Thursday, May 11, 2023 at 3:00 PM MDT",
   "hosts": [
     {
-      "id": "pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l",
+      "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=WsLhwQ3crJ4Q7kNvgHhRU81&_nc_oc=Adi4daqDXshJNCP_w812y2b-RCvbo_1KXt-hv6EL-uqaVzpwh9LugSxeFmCOPoNn_GW3VCAbOD-j4iToUhfMnLls&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=5n59QJ-2JKpUGw6uxMHjZA&oh=00_AYFJbMLJwVW1BYTLV6BpccuIfp-Iaoo5le71h_W9C7jyVg&oe=67FE8F3A",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
-      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l/",
+      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
     },
   ],
   "id": "564972362099646",
@@ -79,7 +79,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100068207392255",
       "name": "Scotiabank Saddledome",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/281352750_2028415974017689_9212573442765953743_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=JWkixMDtNBIQ7kNvgGhb2m3&_nc_oc=AdgNhZL_P83IT5dtgpeA1RvTKexdLwhYZ6v7WLpwCEvn8-RS7nkoegamaV_hFy7XZdtIG28SeHuoMg9HeAVtAitc&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=TtCwV0_lMVMmZG2cHJiipA&oh=00_AYHg2ExEkLvdBly4vRKxXeAJ025xAQShViiRUOgNUVTR7g&oe=67DCFB0B",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/281352750_2028415974017689_9212573442765953743_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=CUtBHBcSvkwQ7kNvgF1RzCF&_nc_oc=Adl0ekulQycJe3WNVmDmyru0Sa0najIK73ywHl7AgZBJT96yEC48Gdp3b5uJm4-wHg5w8voww2SucrbtdpG-4tkI&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYFSk_RvaMxBVGmRk4I-e7zJFSr3Ccneh1w4Wj29Gi2hVg&oe=67F47DCB",
       },
       "type": "User",
       "url": "https://www.facebook.com/scotiabanksaddledome",
@@ -88,7 +88,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100064516969267",
       "name": "Calgary Stampede",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/352087888_1034380311273324_7910170983351471836_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ipjVHGaDKAMQ7kNvgE2qT3o&_nc_oc=Adi86HEmNAJgvU9Ku5sMgmfB-GxE3NeojwGiyOY0kOJ2-7QaFYQq2tJNOvJdS3ivluGQpYoLCHzHeRMVg-9woBoi&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=TtCwV0_lMVMmZG2cHJiipA&oh=00_AYEKk5XYvv1_mLk1MBpYxpeBxN6l79I40innjfOfWqFphQ&oe=67DCDF6B",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/352087888_1034380311273324_7910170983351471836_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=lBA4W9u9D90Q7kNvgGcwYHA&_nc_oc=AdkiOqEJDmcUnPD_t5H0YrNwVcKS-SdQzNd09juXIGMmIR0TzHkY5xtrUdsTxlBmDjklitFWU1aLWEilA4W6zUUg&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYHSvu3-N10ju6FWOWe2sv00GNUsx6qe93c9-qRZE9nnmw&oe=67F4622B",
       },
       "type": "User",
       "url": "https://www.facebook.com/calgarystampede",
@@ -97,7 +97,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100063699336240",
       "name": "Stampede Ent. Inc.",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=EoQq3RA16g0Q7kNvgHZpLId&_nc_oc=Adh_j1ZU22J1ysDP0W_gBvuIQQUOihtvbF8NF9nhWZf-CwusuA_IP8j0xkExgwghpgvefrMszixUCOjPKcIzYguz&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=TtCwV0_lMVMmZG2cHJiipA&oh=00_AYETvXTV-hk_m7UMDFT3taXUlaUBaZknopfZQhkArPofKw&oe=67DCFFC2",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYF6m8bJUe1hod0a7Y_YyFj8Lz0XA1n3Kofxyf7OCn1iRA&oe=67F48282",
       },
       "type": "User",
       "url": "https://www.facebook.com/StampedeEntInc",
@@ -106,7 +106,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
       "id": "100044535845092",
       "name": "Pitbull",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/439064200_1017561226405063_8213471074013536032_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=1&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=EWDYCgmvKTUQ7kNvgF0eugS&_nc_oc=AdhY2c4M3joRpefWXfIOEV8AwLFvmEp0-mm7zfVSIoUD3I81sZ_wTEx61yILP1YPZU9P_9Nf737VzUmDL9v82ZGh&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=TtCwV0_lMVMmZG2cHJiipA&oh=00_AYF31AGIeW3gJ04r4IArqmi99Ifr535eDhOFU1R79aPx3w&oe=67DCDEC3",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/439064200_1017561226405063_8213471074013536032_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=9uxGoyxnuAQQ7kNvgFlLc-P&_nc_oc=AdkZ2n5OkCQoxBZc1BkJFt6xiJIKx-sf8cJtyciHJI9jRBgYFk2Eo89L86KBjsGZ99lXFwZRamwpBxGuTSN2mgM0&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=V2F7xVr1nGnVHwX8KQzlwA&oh=00_AYERx3dl6q8Jc5RHQ_Tk2hmYudds1yeiZPB3ik6O_544wg&oe=67F46183",
       },
       "type": "User",
       "url": "https://www.facebook.com/pitbull",
@@ -136,7 +136,7 @@ Aisle Seat Offer Onsale : Fri, 24 Mar 2023 at 10:00 AM
   "parentEvent": null,
   "photo": {
     "id": "10160954790708641",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/336792249_949153626262984_8332769163095794984_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=d0jM0rlwe-YQ7kNvgEFbew7&_nc_oc=AdiHtXn2gdM8RYWEE7y0LBNRagEZKzAnU_B6LjcrEU94EaViCut2Dv4NXhouxXQZNpJoJ5JKy9Ft-JJxX_wz2sMC&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=WyztIaZm5o9J_udUf_ab7w&oh=00_AYF6a2W8uEKW-TsSAgos6qS7U6EJ1eOab8zAtIBRZP8rGw&oe=67DD11ED",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/336792249_949153626262984_8332769163095794984_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=hhcKOPPcsXsQ7kNvgE7mcQ2&_nc_oc=AdmOYnx2JxZ7ct4ex77OUBfcvVv68EWIen3YbOI8hM4mSzzntG0S9LTPFHBJY7VnGrmYCnfdnh9TZzYvIxtbC2fo&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=tt8QbVfBQaUYzXL2E0cfow&oh=00_AYFsctAcPCjbzFotmnH9nhriuDoNhS6dmSmTxGrmxAR3Ig&oe=67F45C6D",
     "url": "https://www.facebook.com/photo/?fbid=10160954790708641&set=gm.602005851971871",
   },
   "siblingEvents": [],
@@ -175,7 +175,7 @@ More info: https://www.faccalgary.com/easter",
       "id": "100064691376556",
       "name": "FAC Deerfoot",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/460987627_944177641081940_5270929113802053218_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=W1aQGj-8k_sQ7kNvgEyEPQm&_nc_oc=AdgPdbFWmCy-yf9XMry80CQ9O49iEajDU_gamlLNk03u7p7JjiZSSFhgZpR0_ZR30enLSWW9PeQRYJRpU8xvemov&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=CjizvrpZnsSlH_gZYNFxHA&oh=00_AYEiD-SkGHF70GjVecanCieLh9QC5sUjjwEdCdXyr424BA&oe=67DD0A64",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/460987627_944177641081940_5270929113802053218_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=6_4Ericq7OgQ7kNvgGqhW4Y&_nc_oc=AdmHaK1dalJDU__V24mCbetJykOvNixK1iPNkh29O1M1INR_auEeuVQSyr66WVJ7RC27jnvjT7W5mc2VYoT-m3Y2&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yinho4me4PVgi2KmpMJg3Q&oh=00_AYGHxN7iXBkJAtmNaYuh45EqM-j4qn_oLXXPrD-pXK9c4g&oe=67F454E4",
       },
       "type": "User",
       "url": "https://www.facebook.com/facdeerfoot",
@@ -208,7 +208,7 @@ Official Facebook Page for First Alliance Church",
   },
   "photo": {
     "id": "595982989234742",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/481055432_1056019033231133_4786716278309143615_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=g96SsT7S3B8Q7kNvgEQTx89&_nc_oc=AdhKLNrPE_0hXhqHwifYlyiOsW2iSgOS0rnKibKplAAAeBLXJqzdR_dC92urz3A9M1IOcD5LjJv1HrXJoaaxFUMr&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=undek1S-Lu9Qzt4DfPbd_g&oh=00_AYHTnMEO1Tf4mSFV9OAPdXHluddQ1fYTyb_mIYs353_RNQ&oe=67DCE654",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/481055432_1056019033231133_4786716278309143615_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=75d36f&_nc_ohc=Fnd3Pv_xvy0Q7kNvgGg5luk&_nc_oc=AdkWORkOMTHv7RL_P_3dJBB6vW-GWAMEBFN3mqumLGepJauPSPR54iT-8BLKIsFQ9R_P36Wl6M0V0qlUphacvUZ2&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=2wFLk5_yjAfg-veaJQQ2zg&oh=00_AYHDfoWp10NWIqwUK-vwWXp1sfyjS6UfKz0Fi86ceg3hWw&oe=67F46914",
     "url": "https://www.facebook.com/photo/?fbid=595982989234742&set=gm.1137956736879596",
   },
   "siblingEvents": [
@@ -284,7 +284,7 @@ Binoculars are available to borrow for those who need them.",
   "parentEvent": null,
   "photo": {
     "id": "10167524860335261",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/337885002_189168827241357_2737797815564835189_n.jpg?stp=dst-jpg_p960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=75d36f&_nc_ohc=uRvwv1sVvVMQ7kNvgFKgl-y&_nc_oc=AdhlPxNKwyr0rJmKz9P1PZ8OXZCVqQQCGBcwNkIt3pN0Ovpqd5P35VIO0MTlZGAKxWsxEGRuUdy6RZZ4YBg9bf1b&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=vXHMim_yWpZzWqZPPAjDuw&oh=00_AYHPi0IU-Tiwg0nZYmDVrrgQnlrUKA-Rya5lARzJHxMXQg&oe=67DD1231",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/337885002_189168827241357_2737797815564835189_n.jpg?stp=dst-jpg_p960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=75d36f&_nc_ohc=N2sp8WNyvXAQ7kNvgHMlq_b&_nc_oc=AdmAr5X1VdZexCPMuultzHDJVq5zGuS005WCjDU5WZgQkhpxOxWZrKo_YMt9_rjduXoPKGUdXdflF2EbZKRP8nA3&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=FyOdqNaHMV_bkl44Y2ZBHQ&oh=00_AYGnUUHV7eRPt2nxIR2U3ZgO_veZtQkb_wKSwhYFc9AWNA&oe=67F45CB1",
     "url": "https://www.facebook.com/photo/?fbid=10167524860335261&set=gm.252144523936238",
   },
   "siblingEvents": [],
@@ -317,7 +317,7 @@ At the Lilac Festival, there is an activity made for all ages. This could mean a
       "id": "100050510798749",
       "name": "Lilac Festival",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/343412725_1217737712204297_6274770509266232269_n.jpg?stp=c50.34.938.938a_cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=_nS1Y0H-ZVgQ7kNvgHLMwKh&_nc_oc=AdgC_jrjGZ20MjjPdCkts0TMtiRDgrd1YZsmweRb0eEDzpqIx6iHFuSL3FSI57IYx1SSulX7TdJCMEB8aBEHN9Nd&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=l8npj2LvMetF0dXiJ4LbMw&oh=00_AYHublW7hpsWr7laOLmFSoHxzxrV7bkr3Q3JkJsVHkumLw&oe=67DCFB34",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/343412725_1217737712204297_6274770509266232269_n.jpg?stp=c50.34.938.938a_cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=DRc_Hf0Z5u4Q7kNvgGVIYeX&_nc_oc=Adld_eWoI06jV8rI9A0Et0pYe6kB8h_nxfNr93hdKTmsCqidhxKYtnEcfEd0a6dZr1B34NJaDwsdY4xAQsnzK-rJ&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=mHA9NBDdpIChH2OLGWn-eA&oh=00_AYEvcocCQx7GHZCyQf8v9ZZ0jOLdAPcGThGWeFh_vSrUOg&oe=67F47DF4",
       },
       "type": "User",
       "url": "https://www.facebook.com/LilacFestival",
@@ -344,7 +344,7 @@ At the Lilac Festival, there is an activity made for all ages. This could mean a
   "parentEvent": null,
   "photo": {
     "id": "749222690104751",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/472570967_1152279459799070_954455182245359149_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=CrwQgIgnUBEQ7kNvgEwExdb&_nc_oc=AdgI6T0fFQBCSThgkXmhF3ViVEhYtQP_Iwhlamu7V-aJHyyYV8BwWVQfecMy35001FBqgv58qPPgQy1U5-iMlLMf&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=F0NBvsVnQFvjKma7mrCOWA&oh=00_AYFbrrTJ4kBx6w3Fhaj8IHsdXTXTGuBUb3WeGGREfAY-lQ&oe=67DCF394",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/472570967_1152279459799070_954455182245359149_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=CuHA6jyZQOYQ7kNvgG3WefK&_nc_oc=AdkYlKkXZKVlI6XtBW210Ui-mdm9YUTeuiJK9ek4YOjmeLVhl_VLCZL6-WfRew9DVQdALjpnAsYwt_yhevpR_y4e&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=H8ueXL59YU6lgmaD69Tdog&oh=00_AYGOuBrvrPwHCjNMKvEniyXe1HOBeIcKI9DW9STTzU2osw&oe=67F47654",
     "url": "https://www.facebook.com/photo/?fbid=749222690104751&set=gm.719931573255940",
   },
   "siblingEvents": [],
@@ -352,7 +352,7 @@ At the Lilac Festival, there is an activity made for all ages. This could mean a
   "ticketUrl": null,
   "timezone": "UTC-06",
   "url": "https://www.facebook.com/events/719931529922611/",
-  "usersResponded": 5940,
+  "usersResponded": 5939,
   "video": null,
 }
 `;
@@ -365,13 +365,13 @@ exports[`E2E Generates the correct event data for an event with a text location 
   "formattedDate": "Tuesday, April 4, 2023 at 11:00 PM MDT",
   "hosts": [
     {
-      "id": "pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l",
+      "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=WsLhwQ3crJ4Q7kNvgHhRU81&_nc_oc=Adi4daqDXshJNCP_w812y2b-RCvbo_1KXt-hv6EL-uqaVzpwh9LugSxeFmCOPoNn_GW3VCAbOD-j4iToUhfMnLls&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=G_7rWYk5gRhSixGB_kW-eQ&oh=00_AYHj2yfN0aBXpXLweQMu6naW73q3zYlwYo2A6x5y7oVD9w&oe=67FE8F3A",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
-      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l/",
+      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
     },
   ],
   "id": "526262926343074",
@@ -440,7 +440,7 @@ https://www.facebook.com/groups/darkeighties
       "id": "100070821304084",
       "name": "12XU",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/410227062_382882167415824_4051646999230968301_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=oDfXCCPgbxgQ7kNvgGhyPwz&_nc_oc=AditqA-ayIzmX0CMqeqS9GyKsTtZJ_rvnlZrnG84MmPcuOhxp_o7vcOM6CNGmsg5YXGfGhhZeUTSZUpdO5Xl4whM&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=8mpIi1nBUZuZQeTYbOJYVg&oh=00_AYFPCQBI94H_Z8FSWKZnbZXT5djvUPcM3XxbYT_FcNzhZA&oe=67DCF5E6",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/410227062_382882167415824_4051646999230968301_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3fhOL_F0BJYQ7kNvgGFmOkv&_nc_oc=AdmGr9PFwuYsbRfWJkTeEPUmhLWl3te9fSgc8WxMvXqiyG0bPvQ6kbhes3ekIsTB8IRClGE2WmWRBhWEySccc56j&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=8B--XKVD5GWcuUoEJR9IAQ&oh=00_AYGrb7evBBcbLe-8ytVsQYrgmTAWKZgjuO9mvFXwXxdMnA&oe=67F478A6",
       },
       "type": "User",
       "url": "https://www.facebook.com/12XUevents",
@@ -449,7 +449,7 @@ https://www.facebook.com/groups/darkeighties
       "id": "100063904024919",
       "name": "The Dark Eighties",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/332078465_858485495251843_6558149897498817316_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=MI-umX9WKEsQ7kNvgHJunEk&_nc_oc=AdhEDdOzHR8_ziyiyfIB6FLwjZEVcmxehUTmmLqc_fqibtvKzr9fPN0GX2XiQ97E-CN2ZfFVNX9cCJund2l0R_z1&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=8mpIi1nBUZuZQeTYbOJYVg&oh=00_AYFd1kUz24IBHM2_p0cOkTTjpF9m_78K5KgxS-sAzR67sw&oe=67DD0567",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/332078465_858485495251843_6558149897498817316_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=108&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=AU3vP_vEWoYQ7kNvgFfbdrE&_nc_oc=AdnpGa_aIJBpp_5P9HXUcy8YjuUfpSlzDs0Op80FC9PBrASOnAPDtIgIEuU6XwDaIxEvE9z6EeKxNOh0Sm9AkaVl&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=8B--XKVD5GWcuUoEJR9IAQ&oh=00_AYGpQYzRe1-53QnGVUkmRN06FqYiB6b32zo7I6u2GhlCIg&oe=67F48827",
       },
       "type": "User",
       "url": null,
@@ -476,7 +476,7 @@ https://www.facebook.com/groups/darkeighties
   "parentEvent": null,
   "photo": {
     "id": "621131586693637",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/483866251_1107783254695132_4478007887358984133_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=75d36f&_nc_ohc=0V-yUhA3OhwQ7kNvgHZ7D8v&_nc_oc=Adh5i678Kl3674KLNzco2MqV_7a0JLApm4wOWvmmkN2AOURB8bsOiVY8-k1opMLJKLmh-pzrkZUHrHUe9dJBycaT&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=8jLn_W-1qZ3lTE8WmjAQJA&oh=00_AYFlm-BCScJ6pKr2u6QLLi6lWr6z89ulNoP1zOF5WdZKRA&oe=67DCE228",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/483866251_1107783254695132_4478007887358984133_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=75d36f&_nc_ohc=2Zp--_qQUi0Q7kNvgHOdgXt&_nc_oc=AdkhayeOn4jVq8bkbP2mJzcz1i9VF3Er2to2JD2fdFSvp8dd_Mndw-drrxhYhgj5qOLWJZ2L83iyuS_M_uRDtjjd&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=t1Mfn3MpTsm5ylm6JUvdOw&oh=00_AYH8s6fO-5R6jFV4kJICfD8Br91r80EYCT3GEvv3EV-oJA&oe=67F464E8",
     "url": "https://www.facebook.com/photo/?fbid=621131586693637&set=gm.1376686326480508",
   },
   "siblingEvents": [],
@@ -516,7 +516,7 @@ Ateitį kurkime šiandien!
       "id": "100067786593384",
       "name": "Lietuva 2050",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/353748572_586062753663273_3803358940549831479_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=q2BE_Jr-WEkQ7kNvgFBBrXZ&_nc_oc=AdhnG4i5St-2dZcmbOxLyX7-KLQO0rkv7pW5-z2-SddnYVxA59JhAoaCZzh0PPZ25TuDiegTqwN5_nXmIN6jooaj&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=mjFLV6QOE1vuu0Kr8WqN9g&oh=00_AYHlWmem5ERQgPe8jzLJbWCSzqsY0YVC_2vAXpV50CqTkw&oe=67DD0951",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/353748572_586062753663273_3803358940549831479_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=111&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=PwodFXL7tpkQ7kNvgGbdk3H&_nc_oc=Adl868_fFe1vsu6QcDRPtXfXx6VoqyE1httXOgAeLuWuIIqaJSqJdEPMAMioca7vFeYQf2il6bZyF5gFKUrdhoU9&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYGdsNwuIYNE8dimQBAfYzuKhpTW-qFQC5v3Q71LmoiPYg&oe=67F453D1",
       },
       "type": "User",
       "url": "https://www.facebook.com/Lietuva2050",
@@ -525,7 +525,7 @@ Ateitį kurkime šiandien!
       "id": "100039182298687",
       "name": "VU Šiaulių akademija",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/274600858_487344632966234_2522454326585058130_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=105&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=JoZgByASzyUQ7kNvgEIXzAW&_nc_oc=AdgGh8wtbAoHj2Ip9CrMKs2va0rEQpK_wFtLUDhOCze0Y0XC7Y_A6m8caq4ez7qQ0S2U1IBbED69gBxao49_GOjQ&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=mjFLV6QOE1vuu0Kr8WqN9g&oh=00_AYE_95F8Ba6o_P-IgWem9ef4vs7QrxhcbIaXf8EUzp6Alg&oe=67DCF47C",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274600858_487344632966234_2522454326585058130_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=105&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=-fbd_Gl1fikQ7kNvgFg7SMJ&_nc_oc=AdmC9KEhzYbR1sPPGHY858pYGhqog_m_zUHTXVTSgaGq1D1d23UWwBHIjiPKc-2ZtfrJB1p8teHWKRqMuGBANFE_&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYH4q34nYdwbZYy9dLIEv5iXxroF1FDF9yusovwe7nVreQ&oe=67F4773C",
       },
       "type": "User",
       "url": "https://www.facebook.com/siauliu.akademija",
@@ -534,7 +534,7 @@ Ateitį kurkime šiandien!
       "id": "100064306435250",
       "name": "Vilniaus universitetas / Vilnius University",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/274532730_5225887714128805_1147028878997655106_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=4OzvKzFFrzwQ7kNvgFnS_N7&_nc_oc=AdgYCjVsfFcyez_O1r6277fdalo3sPzdWjCbWe8_0bi7Drt5w9Y-0FuwFdZnv6ITagd0QHk6f_kbdTbRxuf1apwK&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=mjFLV6QOE1vuu0Kr8WqN9g&oh=00_AYFrIMf1VLa-xWrhWlhiQrVpX78gRdNnmS8bDykBPdD90A&oe=67DD12F2",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/274532730_5225887714128805_1147028878997655106_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=04xDEPunUMEQ7kNvgErtHIq&_nc_oc=Adn59tBFlUv3veeZv1EhFRvjsaC2azhK93ZA5rClWFF6bw9soWp9f7DErp8qNe4_bWRk6VNwSbWqtuEu5XFeSlhH&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYGK1jbOls3X6CTMIOfm5UOFNwNS_CaBzz0f9koD-XCdIg&oe=67F45D72",
       },
       "type": "User",
       "url": "https://www.facebook.com/VilniusUniversity",
@@ -543,7 +543,7 @@ Ateitį kurkime šiandien!
       "id": "100064644461523",
       "name": "Šiaulių apskrities Povilo Višinskio viešoji biblioteka",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/473965764_1047560367408769_1188670290210731717_n.jpg?stp=c293.0.1414.1414a_cp0_dst-jpg_s74x74_tt6&_nc_cat=100&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=Ovn9ZekpnNYQ7kNvgFUHGhc&_nc_oc=Adg24cEZLu9Z9rIRtwUz-u1uvsxaNswzkmbxl-M0T3TO6ocC3IQDnw1-20aPhF9gC-Ocp4KM9fCysRaNxwRvFSZv&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=mjFLV6QOE1vuu0Kr8WqN9g&oh=00_AYEhYydEtTPQ5cAkxECLFPzUTm5UQmvK2ZEbQjYQXe9MDw&oe=67DCE13A",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/473965764_1047560367408769_1188670290210731717_n.jpg?stp=c293.0.1414.1414a_cp0_dst-jpg_s74x74_tt6&_nc_cat=100&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=WuGDGugjHCQQ7kNvgGIRJKz&_nc_oc=AdncOdOujimgATfzouuTFxiU4rmwIUs0WWEAXplUOppk2tDHYl-Ax1pX1B94XATkT2WKaKJqwmkPzaf5qGk0SEcC&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yaVwnVlY_K25HXNs7lFQPg&oh=00_AYHtfm5kxU9maudZjLY2n0RMDmaZwLJgVX6hAqs_b60bfg&oe=67F463FA",
       },
       "type": "User",
       "url": "https://www.facebook.com/SAVB.info",
@@ -567,7 +567,7 @@ Ateitį kurkime šiandien!
   "usersResponded": 123,
   "video": {
     "id": "2194658774256880",
-    "thumbnailUri": "https://scontent-den2-1.xx.fbcdn.net/v/t15.5256-10/343286097_763205485254382_1688962917143675368_n.jpg?stp=dst-jpg_s960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=282d23&_nc_ohc=wB2TA5DZLvUQ7kNvgFKqq67&_nc_oc=AdikCK1tsqrV1XFyywGTXimYDIR9yMm8MU8njJjcLqLvxm4nntg9FkHom-w0zBAfgH7qmneKYQspUyBddM-QlMG6&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=bUUWzQTyrTymwOXD1HS4hQ&oh=00_AYGsjW4JfQCZCmtvLxx5m1hjeHQM5sP2HLoLyYaN63d8aA&oe=67DCE76B",
+    "thumbnailUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t15.5256-10/343286097_763205485254382_1688962917143675368_n.jpg?stp=dst-jpg_s960x960_tt6&_nc_cat=107&ccb=1-7&_nc_sid=282d23&_nc_ohc=-VXX72wKevMQ7kNvgES91oA&_nc_oc=AdkpDqP7104s1DXZLqFyW09SduLJgkEHzOdbTmu_eZElfn--VtZ4-xMHrruD4CgpODsB3FOR43QR_4D7iRAZgGfq&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=hpvG5SAj0CzYErSVWx0fag&oh=00_AYEJtKos0GVydlcNv2TlTnZmmST3ZB7DiuBV-ndXcHDDng&oe=67F46A2B",
     "url": "https://www.facebook.com/Lietuva2050/videos/2194658774256880/",
   },
 }
@@ -591,7 +591,7 @@ Tickets are ON SALE NOW!",
       "id": "100064709654009",
       "name": "All Elite Wrestling",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/448627833_865600602273587_4050110030248245393_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=1&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3KWtAijch0MQ7kNvgHSMgxG&_nc_oc=AdgS0x6NkYM5sbXKZ0JX7CSSSnVE9D5yfLWbo0UbKCcT_81LYG3Eeywimkcslx08g2wzcsHkPJsdkyCGR_WoSAUx&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=GlMKlZIkqVwlGxlhop8C1g&oh=00_AYGz6rmBOdy5Gt499pKwUvF-FJzqnqrDx8ZEAIA5O2Mbzw&oe=67DCE7A9",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/448627833_865600602273587_4050110030248245393_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=103&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=8KTjVe07mKUQ7kNvgEXUzG-&_nc_oc=Adk7x075UR7_4rekBgjetdyJjOqVehwE6lNfqmWmD0229WiecWOiQThNFQ0pL8Nb2WsDDvyI6rHqf-gHF25WMwXX&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=nPjsuGgp63cBsUmG3DONGg&oh=00_AYFa3vxTCSxHi5N4GusXoItKQh2XQnqpSN3SUrRxsGyTkg&oe=67F46A69",
       },
       "type": "User",
       "url": "https://www.facebook.com/AEW",
@@ -600,7 +600,7 @@ Tickets are ON SALE NOW!",
       "id": "100063699336240",
       "name": "Stampede Ent. Inc.",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=EoQq3RA16g0Q7kNvgHZpLId&_nc_oc=Adh_j1ZU22J1ysDP0W_gBvuIQQUOihtvbF8NF9nhWZf-CwusuA_IP8j0xkExgwghpgvefrMszixUCOjPKcIzYguz&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=GlMKlZIkqVwlGxlhop8C1g&oh=00_AYHluKItTbVaighowdUE1qCYMumUq5phwCTRKOVp4v4XfA&oe=67DCFFC2",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/294695496_453263513473623_3023392462933132753_n.jpg?stp=cp0_dst-jpg_s74x74_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=3qSYYj5rw9sQ7kNvgHZfbqk&_nc_oc=AdkRcJP8GGtN6e19WwAgkJZjyVRfCq0V7Wr7BBlc48Z8JCek6kouwIGGb_95lAYvmvdQ0MtB7NY7jZQ0b7_M3qVt&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=nPjsuGgp63cBsUmG3DONGg&oh=00_AYGaYm5uUBqNxEKDb2CG7p80Kv7KQI1rmyKs2Os05kC1TA&oe=67F48282",
       },
       "type": "User",
       "url": "https://www.facebook.com/StampedeEntInc",
@@ -630,7 +630,7 @@ Tickets are ON SALE NOW!",
   "parentEvent": null,
   "photo": {
     "id": "1273089803342464",
-    "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t39.30808-6/473081369_1630277110957063_1481524804345515679_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=HJQ3uxRc5ZAQ7kNvgHUXJ5P&_nc_oc=AdjILWS4M0d-YSaJVJGXh8ewkvHgag42nFLd8ZLIG30oWkrZiOWYgd4ZElJfDx4DfVAP70f87tP1CUQGY6UuwoM6&_nc_zt=23&_nc_ht=scontent-den2-1.xx&_nc_gid=azylL7ohAdDvm17H-8xKhg&oh=00_AYFi-wqZhqVG3gUuH2L_WlC0CCqx5mCnd2M2-p2FiXgMUg&oe=67DD0036",
+    "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/473081369_1630277110957063_1481524804345515679_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=75d36f&_nc_ohc=LT3de8An608Q7kNvgGwzhoB&_nc_oc=AdnvoqwE6-6azAFH06hLCkJPXesvKfQj8kXamNBTJJFC0cJteHGTjqvRM483RtjmFaIs3dw3YsU1G3CwuIufzNhy&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=e7R2_1Ufi3Lc9pvD12jrPQ&oh=00_AYHBEQCGUbojTJn5IF_jLz8pcfJtTye4Z0p4i9hl-9A-Zg&oe=67F482F6",
     "url": "https://www.facebook.com/photo/?fbid=1273089803342464&set=gm.977705193657933",
   },
   "siblingEvents": [],
@@ -643,47 +643,6 @@ Tickets are ON SALE NOW!",
 }
 `;
 
-exports[`E2E Generates the correct event data for an event with no location 1`] = `
-{
-  "description": "Birželio 1 d., ketvirtadienį, 16 val. vyks virtualus renginys „#TAPKMOKYTOJU. Mokomojo dalyko pedagogika: istorija ir geografija“, kuriame dėstytojai, studentai, absolventai dalinsis savo įkvepiančiomis istorijomis, įžvalgomis apie studijų programą bei mokytojo darbą.
-
-Mokomojo dalyko pedagogika: istorija ir geografija bakalauro programa vykdoma Kaune ir Vilniuje.
-
-Registracija: https://forms.office.com/e/DvfJn8q27D",
-  "endTimestamp": 1685629800,
-  "formattedDate": "Thursday, June 1, 2023 at 4:00 PM – 5:30 PM EEST",
-  "hosts": [
-    {
-      "id": "100064711685049",
-      "name": "VDU Švietimo akademija",
-      "photo": {
-        "imageUri": "https://scontent-sjc3-1.xx.fbcdn.net/v/t39.30808-1/274685098_5567767706572475_1252348629032694585_n.jpg?stp=cp0_dst-jpg_p74x74&_nc_cat=109&ccb=1-7&_nc_sid=5f2048&_nc_ohc=11rg-xddKV4Q7kNvgGhD9y-&_nc_ht=scontent-sjc3-1.xx&oh=00_AYD5VmpY3xZ1trCYHQqoOnUxYTAhdyFkF0vzTpajo-TkCg&oe=665B08BB",
-      },
-      "type": "User",
-      "url": "https://www.facebook.com/VDU.svietimo.akademija",
-    },
-  ],
-  "id": "782998640138266",
-  "isOnline": false,
-  "location": null,
-  "name": "Virtualus renginys „#TAPKMOKYTOJU. Mokomojo dalyko pedagogika: istorija ir geografija“ ",
-  "onlineDetails": null,
-  "parentEvent": null,
-  "photo": {
-    "id": "6986078114741420",
-    "imageUri": "https://scontent-sjc3-1.xx.fbcdn.net/v/t39.30808-6/349523504_596340745925274_3047478399487167752_n.jpg?_nc_cat=110&ccb=1-7&_nc_sid=5f2048&_nc_ohc=Ug3itfxfET4Q7kNvgE1UV2f&_nc_ht=scontent-sjc3-1.xx&oh=00_AYA6QcM4udpDAHpbVAyitQOTZx77lBwgOKA8JB5TAc_tNQ&oe=665B0722",
-    "url": "https://www.facebook.com/photo/?fbid=6986078114741420&set=gm.782998683471595",
-  },
-  "siblingEvents": [],
-  "startTimestamp": 1685624400,
-  "ticketUrl": null,
-  "timezone": "UTC+03",
-  "url": "https://www.facebook.com/events/782998640138266/",
-  "usersResponded": 3,
-  "video": null,
-}
-`;
-
 exports[`E2E Generates the correct event data for an online event with a third-party URL 1`] = `
 {
   "categories": [],
@@ -692,13 +651,13 @@ exports[`E2E Generates the correct event data for an online event with a third-p
   "formattedDate": "Friday, June 16, 2023 at 4:00 PM MDT",
   "hosts": [
     {
-      "id": "pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l",
+      "id": "pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl",
       "name": "Joe Smith",
       "photo": {
-        "imageUri": "https://scontent-den2-1.xx.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=1&ccb=1-7&_nc_sid=136b72&_nc_ohc=WsLhwQ3crJ4Q7kNvgHhRU81&_nc_oc=Adi4daqDXshJNCP_w812y2b-RCvbo_1KXt-hv6EL-uqaVzpwh9LugSxeFmCOPoNn_GW3VCAbOD-j4iToUhfMnLls&_nc_zt=24&_nc_ht=scontent-den2-1.xx&_nc_gid=C4WchNGgpyibMwT_cSCN5Q&oh=00_AYFrYipRgLtMGWh2fTf_lJhUZmDNtBdDSLyCULrxlbiTgA&oe=67FE8F3A",
+        "imageUri": "https://scontent.fprg1-1.fna.fbcdn.net/v/t1.30497-1/453178253_471506465671661_2781666950760530985_n.png?stp=cp0_dst-png_s74x74&_nc_cat=110&ccb=1-7&_nc_sid=136b72&_nc_ohc=1BwdynYvBPkQ7kNvgGLfETp&_nc_oc=AdkwuZIOnFTbk3I7afTKTG1Y24wA-UuhcYr0n9h4ZxCFntUzHEHLbU_E2qgT8ccBkSErM6J-xwBqUPQRwjrFDWLc&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&oh=00_AYG--KDXOOWQnf6M4UOrL3ijmXai-Y-yarGjhvNhR9KQLg&oe=681611FA",
       },
       "type": "User",
-      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bQFZ9MazsRB13NkebQwuDh4YbAvedfDCapsq6AY75C3mShYsNbZCRvEws9QJTDA7l/",
+      "url": "https://www.facebook.com/people/Joe-Smith/pfbid0bGj6B1rxxo3QFADeCQUvdfXYSdaSt4bVkxQ5VLTSr2YfkxooN65p4ZhmazVPc5iUl/",
     },
   ],
   "id": "760928342374546",

--- a/src/tests/e2e.test.ts
+++ b/src/tests/e2e.test.ts
@@ -1,4 +1,8 @@
-import { scrapeFbEvent } from '../index';
+import {
+  scrapeFbEvent,
+  scrapeFbEventListFromGroup,
+  scrapeFbEventListFromPage
+} from '../index';
 
 // TODO: Try a private event, see if we can get a specific error message
 // https://www.facebook.com/events/1637281650028494/?acontext=%7B%22event_action_history%22%3A[%7B%22extra_data%22%3A%22%22%2C%22mechanism%22%3A%22surface%22%2C%22surface%22%3A%22create_dialog%22%7D%2C%7B%22extra_data%22%3A%22%22%2C%22mechanism%22%3A%22left_rail%22%2C%22surface%22%3A%22bookmark%22%7D%2C%7B%22extra_data%22%3A%22%22%2C%22mechanism%22%3A%22surface%22%2C%22surface%22%3A%22create_dialog%22%7D]%2C%22ref_notif_type%22%3Anull%7D
@@ -84,4 +88,35 @@ describe('E2E', () => {
   //   const eventData = await scrapeFbEvent(url);
   //   expect(eventData).toMatchSnapshot();
   // });
+
+  it('Generates the correct event data for past events from page', async () => {
+    const url = 'https://www.facebook.com/lacalle8prague/past_hosted_events';
+    const eventData = await scrapeFbEventListFromPage(url);
+    expect(eventData).toMatchSnapshot();
+  });
+
+  it('Generates the correct event data for upcoming events from page', async () => {
+    const url =
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events';
+    const eventData = await scrapeFbEventListFromPage(url);
+    expect(eventData).toMatchSnapshot();
+  });
+
+  it('Generates the correct event data for upcoming events from page', async () => {
+    const url = 'https://www.facebook.com/lacalle8prague';
+    const eventData = await scrapeFbEventListFromPage(url);
+    expect(eventData).toMatchSnapshot();
+  });
+
+  it('Generates the correct event data for events from group', async () => {
+    const url = 'https://www.facebook.com/groups/409785992417637/events';
+    const eventData = await scrapeFbEventListFromGroup(url);
+    expect(eventData).toMatchSnapshot();
+  });
+
+  it('Generates the correct event data for events from group page', async () => {
+    const url = 'https://www.facebook.com/groups/409785992417637';
+    const eventData = await scrapeFbEventListFromGroup(url);
+    expect(eventData).toMatchSnapshot();
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,3 +96,12 @@ export interface EventCategory {
 export interface ScrapeOptions {
   proxy?: AxiosProxyConfig;
 }
+
+export interface ShortEventData {
+  id: string;
+  name: string;
+  url: string;
+  date: string;
+  isCanceled: boolean;
+  isPast: boolean;
+}

--- a/src/utils/eventListParser.ts
+++ b/src/utils/eventListParser.ts
@@ -1,0 +1,69 @@
+import { findJsonInString } from './json';
+import { ShortEventData } from '../types';
+import { EventType } from '../enums';
+
+export const getEventListFromPage = (
+  html: string
+): Pick<
+  ShortEventData,
+  'id' | 'name' | 'url' | 'date' | 'isCanceled' | 'isPast'
+>[] => {
+  const { jsonData } = findJsonInString(html, 'collection');
+
+  if (!jsonData) {
+    throw new Error(
+      'No event data found, please verify that your URL is correct and the events are accessible without authentication'
+    );
+  }
+
+  const events: ShortEventData[] = [];
+
+  jsonData.pageItems.edges.forEach((event: any) => {
+    events.push({
+      id: event.node.node.id,
+      name: event.node.node.name,
+      url: event.node.node.url,
+      date: event.node.node.day_time_sentence,
+      isCanceled: event.node.node.is_canceled,
+      isPast: event.node.actions_renderer.event.is_past
+    });
+  });
+
+  return events;
+};
+
+export const getEventListFromGroup = (
+  html: string,
+  type: EventType = EventType.Upcoming
+): Pick<
+  ShortEventData,
+  'id' | 'name' | 'url' | 'date' | 'isCanceled' | 'isPast'
+>[] => {
+  const { jsonData } = findJsonInString(
+    html,
+    type === EventType.Upcoming ? 'upcoming_events' : 'past_events'
+  );
+
+  if (!jsonData) {
+    throw new Error(
+      'No event data found, please verify that your URL is correct and the events are accessible without authentication'
+    );
+  }
+
+  const events: ShortEventData[] = [];
+
+  if (jsonData.edges.length > 0) {
+    jsonData.edges.forEach((event: any) => {
+      events.push({
+        id: event.node.id,
+        name: event.node.name,
+        url: event.node.url,
+        date: event.node.day_time_sentence,
+        isCanceled: event.node.is_canceled,
+        isPast: event.node.is_past
+      });
+    });
+  }
+
+  return events;
+};

--- a/src/utils/eventListParser.ts
+++ b/src/utils/eventListParser.ts
@@ -2,7 +2,7 @@ import { findJsonInString } from './json';
 import { ShortEventData } from '../types';
 import { EventType } from '../enums';
 
-export const getEventListFromPage = (
+export const getEventListFromPageOrProfile = (
   html: string
 ): Pick<
   ShortEventData,

--- a/src/utils/tests/data/eventListGroupData.ts
+++ b/src/utils/tests/data/eventListGroupData.ts
@@ -1,0 +1,390 @@
+export const eventListGroupData = {
+  edges: [
+    {
+      node: {
+        id: '916236709985575',
+        rsvp_button_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            id: '916236709985575',
+            connection_style: 'INTERESTED',
+            can_viewer_join: false,
+            can_viewer_watch: false,
+            can_viewer_unwatch: false,
+            viewer_watch_status: 'UNWATCHED',
+            if_viewer_can_see_going_button: null,
+            event_connection_data_privacy_scope: null,
+            privacy_scope_for_toast: null,
+            can_join_group_chat: false,
+            created_for_group: null,
+            chat: null
+          },
+          __module_operation_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer.react'
+          }
+        },
+        rsvp_button_group_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            should_show_recurring_event_rsvp_button: false,
+            id: '916236709985575',
+            can_join_group_chat: false,
+            can_viewer_watch: false,
+            chat: null,
+            connection_style: 'INTERESTED',
+            created_for_group: null,
+            if_viewer_can_see_going_button: null,
+            is_past: true,
+            show_post_rsvp_dialog: false,
+            viewer_watch_status: 'UNWATCHED',
+            can_viewer_unwatch: false,
+            viewer_watch_all_status_for_recurring_events: null,
+            event_connection_data_privacy_scope: null
+          },
+          __module_operation_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer.react'
+          }
+        },
+        privacy_scope_for_toast: null,
+        rsvp_style: 'PUBLIC_RSVP_STYLE',
+        should_show_recurring_event_rsvp_button: false,
+        viewer_guest_status: 'UNKNOWN',
+        viewer_watch_status: 'UNWATCHED',
+        should_show_horizon_rsvp_warning: false,
+        event_kind: 'PUBLIC_TYPE',
+        can_viewer_invite: false,
+        can_page_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_followers: false,
+        acting_account_name: null,
+        acting_account_id: '0',
+        if_workplace_event: null,
+        eventUrl: 'https://www.facebook.com/events/916236709985575/',
+        can_boost_event_renderer: null,
+        can_viewer_see_rsvp_button: false,
+        can_viewer_share: true,
+        has_header_action_menu_items: true,
+        is_event_draft: false,
+        if_viewer_can_duplicate_event: null,
+        profile_plus_admin_id_if_self: null,
+        profile_plus_admin_name_if_self: null,
+        if_viewer_can_publish_draft_event: null,
+        parent_if_exists_or_self: { id: '916236709985575' },
+        event_for_edit_flow: {
+          if_viewer_can_edit: null,
+          id: '916236709985575'
+        },
+        is_eligible_for_poe_view_as_visitor_button: false,
+        is_past: true,
+        chat: null,
+        go_to_horizon_event_button_renderer: {
+          event: null,
+          __module_operation_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            {
+              __dr: 'EventCometGoToHorizonEventButton_renderer$normalization.graphql'
+            },
+          __module_component_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            { __dr: 'EventCometGoToHorizonEventButton.react' }
+        },
+        name: 'NEW YEAR EVE 2025',
+        is_canceled: false,
+        day_time_sentence: 'Tue, Dec 31, 2024',
+        event_creator: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/291632323_554825212675900_7285952090469748033_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ew1usRkejEoQ7kNvgE5-s8x&_nc_oc=Adl1or40DTUoWD820jj2BK5Esj1WSvwRaOD9aDiMG7d98oVru1_0kL12GyFwmmJLKvhjlegPd_Cf75IvFJwwnulz&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=32_dYswqaKif3h8wHLYMSA&oh=00_AYFdvNiKkfqP0e7EyOLackWwvYNxOEojjX_4_igxAjvXKw&oe=67F44CEF'
+          },
+          name: 'La Calle 8 - Prague',
+          id: '100044452793920'
+        },
+        shared_in_group_by: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/291632323_554825212675900_7285952090469748033_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ew1usRkejEoQ7kNvgE5-s8x&_nc_oc=Adl1or40DTUoWD820jj2BK5Esj1WSvwRaOD9aDiMG7d98oVru1_0kL12GyFwmmJLKvhjlegPd_Cf75IvFJwwnulz&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=32_dYswqaKif3h8wHLYMSA&oh=00_AYFdvNiKkfqP0e7EyOLackWwvYNxOEojjX_4_igxAjvXKw&oe=67F44CEF'
+          },
+          name: 'La Calle 8 - Prague',
+          id: '100044452793920'
+        },
+        cover_photo: {
+          // photo: { focus: [Object], small_image: [Object], id: '1190903152401433' }
+        },
+        url: 'https://www.facebook.com/events/916236709985575/',
+        __typename: 'Event'
+      },
+      cursor:
+        'AQHRCwgA60jAb1m3tJAxRQFizRUT-_lK33h4sfeOqTEDLJP-BmZE2YN412uEdDm8ThRJsht8IGHEvV0U7ZdUrXEKRg'
+    },
+    {
+      node: {
+        id: '591932410074832',
+        rsvp_button_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            id: '591932410074832',
+            connection_style: 'INTERESTED',
+            can_viewer_join: false,
+            can_viewer_watch: false,
+            can_viewer_unwatch: false,
+            viewer_watch_status: 'UNWATCHED',
+            if_viewer_can_see_going_button: null,
+            event_connection_data_privacy_scope: null,
+            privacy_scope_for_toast: null,
+            can_join_group_chat: false,
+            created_for_group: null,
+            chat: null
+          },
+          __module_operation_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer.react'
+          }
+        },
+        rsvp_button_group_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            should_show_recurring_event_rsvp_button: false,
+            id: '591932410074832',
+            can_join_group_chat: false,
+            can_viewer_watch: false,
+            chat: null,
+            connection_style: 'INTERESTED',
+            created_for_group: null,
+            if_viewer_can_see_going_button: null,
+            is_past: true,
+            show_post_rsvp_dialog: false,
+            viewer_watch_status: 'UNWATCHED',
+            can_viewer_unwatch: false,
+            viewer_watch_all_status_for_recurring_events: null,
+            event_connection_data_privacy_scope: null
+          },
+          __module_operation_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer.react'
+          }
+        },
+        privacy_scope_for_toast: null,
+        rsvp_style: 'PUBLIC_RSVP_STYLE',
+        should_show_recurring_event_rsvp_button: false,
+        viewer_guest_status: 'UNKNOWN',
+        viewer_watch_status: 'UNWATCHED',
+        should_show_horizon_rsvp_warning: false,
+        event_kind: 'PUBLIC_TYPE',
+        can_viewer_invite: false,
+        can_page_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_followers: false,
+        acting_account_name: null,
+        acting_account_id: '0',
+        if_workplace_event: null,
+        eventUrl: 'https://www.facebook.com/events/591932410074832/',
+        can_boost_event_renderer: null,
+        can_viewer_see_rsvp_button: false,
+        can_viewer_share: true,
+        has_header_action_menu_items: true,
+        is_event_draft: false,
+        if_viewer_can_duplicate_event: null,
+        profile_plus_admin_id_if_self: null,
+        profile_plus_admin_name_if_self: null,
+        if_viewer_can_publish_draft_event: null,
+        parent_if_exists_or_self: { id: '591932410074832' },
+        event_for_edit_flow: {
+          if_viewer_can_edit: null,
+          id: '591932410074832'
+        },
+        is_eligible_for_poe_view_as_visitor_button: false,
+        is_past: true,
+        chat: null,
+        go_to_horizon_event_button_renderer: {
+          event: null,
+          __module_operation_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            {
+              __dr: 'EventCometGoToHorizonEventButton_renderer$normalization.graphql'
+            },
+          __module_component_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            { __dr: 'EventCometGoToHorizonEventButton.react' }
+        },
+        name: 'REGGAETON NIGHT',
+        is_canceled: false,
+        day_time_sentence: 'Fri, Nov 22, 2024',
+        event_creator: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/456814620_1002774621646132_7595361602686556522_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=101&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=HCZGvTNgK2wQ7kNvgFPlek4&_nc_oc=AdmIE_VXmhVGIjFHHRZVGmSCLRg_CQyAjZgxTUEjQ6rZ3s3Qs1yh_mZaC4PskV2VEEqYdmaAh7o6h08bmcFxt4H8&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=rlFiAX1AYzE7Ezp3sej9pA&oh=00_AYEd6mgC-Tk_3SeAnMZU_qj_mYPokQEuD5uI5TiYIFJHbA&oe=67F4650B'
+          },
+          name: 'PARTY HARD Prague',
+          id: '100057408101552'
+        },
+        shared_in_group_by: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/291632323_554825212675900_7285952090469748033_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ew1usRkejEoQ7kNvgE5-s8x&_nc_oc=Adl1or40DTUoWD820jj2BK5Esj1WSvwRaOD9aDiMG7d98oVru1_0kL12GyFwmmJLKvhjlegPd_Cf75IvFJwwnulz&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=rlFiAX1AYzE7Ezp3sej9pA&oh=00_AYHHQIZrIfiJkavausOjTPKu9Net4uY3-aUyKNClVsvh8Q&oe=67F44CEF'
+          },
+          name: 'La Calle 8 - Prague',
+          id: '100044452793920'
+        },
+        cover_photo: {
+          // photo: { focus: [Object], small_image: [Object], id: '1062923592297901' }
+        },
+        url: 'https://www.facebook.com/events/591932410074832/',
+        __typename: 'Event'
+      },
+      cursor:
+        'AQHRD9CJklwW5Ll6G40SJp1fm9iDxRTe66U09Tg2n5o14xo0NRvkHJV_l-_6V_EfP2Xy_2BOQtBbPCgm3iDcPYMb8A'
+    },
+    {
+      node: {
+        id: '1103230308135807',
+        rsvp_button_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            id: '1103230308135807',
+            connection_style: 'INTERESTED',
+            can_viewer_join: false,
+            can_viewer_watch: false,
+            can_viewer_unwatch: false,
+            viewer_watch_status: 'UNWATCHED',
+            if_viewer_can_see_going_button: null,
+            event_connection_data_privacy_scope: null,
+            privacy_scope_for_toast: null,
+            can_join_group_chat: false,
+            created_for_group: null,
+            chat: null
+          },
+          __module_operation_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButton_event: {
+            __dr: 'PublicEventCometRSVPButtonRenderer.react'
+          }
+        },
+        rsvp_button_group_renderer: {
+          __typename: 'PublicRsvpStyleRenderer',
+          event: {
+            should_show_recurring_event_rsvp_button: false,
+            id: '1103230308135807',
+            can_join_group_chat: false,
+            can_viewer_watch: false,
+            chat: null,
+            connection_style: 'INTERESTED',
+            created_for_group: null,
+            if_viewer_can_see_going_button: null,
+            is_past: true,
+            show_post_rsvp_dialog: false,
+            viewer_watch_status: 'UNWATCHED',
+            can_viewer_unwatch: false,
+            viewer_watch_all_status_for_recurring_events: null,
+            event_connection_data_privacy_scope: null
+          },
+          __module_operation_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer_rsvpStyleRenderer$normalization.graphql'
+          },
+          __module_component_EventCometUniversalRSVPButtonGroup_event: {
+            __dr: 'PublicEventCometRSVPButtonGroupRenderer.react'
+          }
+        },
+        privacy_scope_for_toast: null,
+        rsvp_style: 'PUBLIC_RSVP_STYLE',
+        should_show_recurring_event_rsvp_button: false,
+        viewer_guest_status: 'UNKNOWN',
+        viewer_watch_status: 'UNWATCHED',
+        should_show_horizon_rsvp_warning: false,
+        event_kind: 'PUBLIC_TYPE',
+        can_viewer_invite: false,
+        can_page_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_as_user: false,
+        can_profile_plus_viewer_invite_followers: false,
+        acting_account_name: null,
+        acting_account_id: '0',
+        if_workplace_event: null,
+        eventUrl: 'https://www.facebook.com/events/1103230308135807/',
+        can_boost_event_renderer: null,
+        can_viewer_see_rsvp_button: false,
+        can_viewer_share: true,
+        has_header_action_menu_items: true,
+        is_event_draft: false,
+        if_viewer_can_duplicate_event: null,
+        profile_plus_admin_id_if_self: null,
+        profile_plus_admin_name_if_self: null,
+        if_viewer_can_publish_draft_event: null,
+        parent_if_exists_or_self: { id: '1103230308135807' },
+        event_for_edit_flow: {
+          if_viewer_can_edit: null,
+          id: '1103230308135807'
+        },
+        is_eligible_for_poe_view_as_visitor_button: false,
+        is_past: true,
+        chat: null,
+        go_to_horizon_event_button_renderer: {
+          event: null,
+          __module_operation_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            {
+              __dr: 'EventCometGoToHorizonEventButton_renderer$normalization.graphql'
+            },
+          __module_component_useEventCometGetPermalinkActionButtons_event_go_to_horizon_event_button_renderer:
+            { __dr: 'EventCometGoToHorizonEventButton.react' }
+        },
+        name: 'FIESTA LATINA',
+        is_canceled: false,
+        day_time_sentence: 'Sat, Nov 9, 2024',
+        event_creator: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/291632323_554825212675900_7285952090469748033_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ew1usRkejEoQ7kNvgE5-s8x&_nc_oc=Adl1or40DTUoWD820jj2BK5Esj1WSvwRaOD9aDiMG7d98oVru1_0kL12GyFwmmJLKvhjlegPd_Cf75IvFJwwnulz&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=HqsUSJIonutjDVVwr-qe5w&oh=00_AYHw7qCMHnGWVL-wC4HnCKx-NA3rxVphJde-POMsYfCofA&oe=67F44CEF'
+          },
+          name: 'La Calle 8 - Prague',
+          id: '100044452793920'
+        },
+        shared_in_group_by: {
+          __typename: 'User',
+          __isEntity: 'User',
+          url: null,
+          profile_picture: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-1/291632323_554825212675900_7285952090469748033_n.jpg?stp=cp0_dst-jpg_s48x48_tt6&_nc_cat=104&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=ew1usRkejEoQ7kNvgE5-s8x&_nc_oc=Adl1or40DTUoWD820jj2BK5Esj1WSvwRaOD9aDiMG7d98oVru1_0kL12GyFwmmJLKvhjlegPd_Cf75IvFJwwnulz&_nc_zt=24&_nc_ht=scontent.fprg1-1.fna&_nc_gid=HqsUSJIonutjDVVwr-qe5w&oh=00_AYHw7qCMHnGWVL-wC4HnCKx-NA3rxVphJde-POMsYfCofA&oe=67F44CEF'
+          },
+          name: 'La Calle 8 - Prague',
+          id: '100044452793920'
+        },
+        cover_photo: {
+          // photo: { focus: [Object], small_image: [Object], id: '1149485386543210' }
+        },
+        url: 'https://www.facebook.com/events/1103230308135807/',
+        __typename: 'Event'
+      },
+      cursor:
+        'AQHRxFYIqikWePsUucI49iXou4AgwL5tB-16gOHE-xCRD6xojLoDViZ1B0XjyTa52ZTaTAMsqvJkLspTSjC41KFgzA'
+    }
+  ],
+  page_info: {
+    end_cursor:
+      'AQHRGVPzsX2pziJJe1BD49lbtIEt1gKJwYs2sFaeoAAlA0E1-5xFtB1pG4ieeb4vQ3R3szNJxZUMcC6JQkrEf_-lYA',
+    has_next_page: true
+  }
+};
+
+export const eventListGroupEmptyData = {
+  edges: [],
+  page_info: {
+    end_cursor:
+      'AQHRGVPzsX2pziJJe1BD49lbtIEt1gKJwYs2sFaeoAAlA0E1-5xFtB1pG4ieeb4vQ3R3szNJxZUMcC6JQkrEf_-lYA',
+    has_next_page: false
+  }
+};

--- a/src/utils/tests/data/eventListPageData.ts
+++ b/src/utils/tests/data/eventListPageData.ts
@@ -1,0 +1,232 @@
+export const eventListPageData = {
+  name: 'Past',
+  id: 'YXBwX2NvbGxlY3Rpb246MTAwMDQ0NDUyNzkzOTIwOjIzNDQwNjEwMzM6MjEw',
+  items: { count: 781 },
+  pageItems: {
+    edges: [
+      {
+        node: {
+          id: 'YXBwX2l0ZW06MTAwMDQ0NDUyNzkzOTIwOjIzNDQwNjEwMzM6MjEwOjoxMzcyMzI3NjgzNzAxMjE4',
+          node: {
+            __typename: 'Event',
+            id: '1372327683701218',
+            name: 'Bachata & Salsa: FREE Open Class + Party',
+            is_canceled: false,
+            event_creator: {
+              __typename: 'User',
+              __isEntity: 'User',
+              url: 'https://www.facebook.com/welovesalsa.cz',
+              name: 'WE LOVE SALSA & BACHATA PRAGUE',
+              id: '100065523248074'
+            },
+            event_place: {
+              __typename: 'FreeformPlace',
+              contextual_name: 'FU Club & Lounge',
+              // location: [Object],
+              __isNode: 'FreeformPlace',
+              id: '1028340926026673'
+            },
+            day_time_sentence: 'Tue, Apr 1',
+            url: 'https://www.facebook.com/events/1372327683701218/',
+            gif_cover_photo: null,
+            cover_video: null,
+            __isEntity: 'Event'
+          },
+          image: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/487776532_1028341062693326_9113608468399343668_n.jpg?stp=c131.0.1160.800a_dst-jpg_s235x165_tt6&_nc_cat=103&ccb=1-7&_nc_sid=4bdd9b&_nc_ohc=w5VBHNMTvxoQ7kNvgH9pYte&_nc_oc=AdnoczqL1v3TLZ321E3W-Q2CW0uIeTC5suOXbQ-1duPIA5MlRqUc7PTJ-HqO-ekKDgCmBXrjL6381qerhjh9cBvo&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=bzCxxxC3KkvQtEyddkvRAQ&oh=00_AYFRkIx-JGRnMlyvv0mnVPjOxK-z3WTxIaITa5rRIAG8eQ&oe=67F459F9'
+          },
+          url: 'https://www.facebook.com/events/1372327683701218/',
+          actions_renderer: {
+            __typename: 'TimelineAppCollectionItemEventsListActionsRenderer',
+            event: {
+              id: '1372327683701218',
+              eventUrl: 'https://www.facebook.com/events/1372327683701218/',
+              can_page_viewer_invite_as_user: false,
+              can_viewer_invite: false,
+              can_viewer_rsvp: false,
+              can_viewer_share: true,
+              event_kind: 'PUBLIC_TYPE',
+              if_viewer_can_duplicate_event: null,
+              is_happening_now: false,
+              is_online_or_detected_online: false,
+              is_past: true,
+              is_viewer_host: false,
+              start_timestamp: 1743530400,
+              // rsvp_button_renderer: [Object],
+              online_event_setup: null,
+              // parent_if_exists_or_self: [Object],
+              live_virtual_event_info: null
+            },
+            __module_operation_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer_actionsRenderer$normalization.graphql'
+              },
+            __module_component_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer.react'
+              }
+          },
+          privacy_scope: null,
+          __typename: 'TimelineAppCollectionItem'
+        },
+        cursor:
+          'AQHR-b4yZEQs-RcEPDpDV4tsincrxA8YAhQDmOOkUKW0oJcOt9QO0M9ARwdHElQXRsTNhviMpQKr3O2gTp1EPcx4gg'
+      },
+      {
+        node: {
+          id: 'YXBwX2l0ZW06MTAwMDQ0NDUyNzkzOTIwOjIzNDQwNjEwMzM6MjEwOjoxMzY5MjAwOTU3NTY5MjYy',
+          node: {
+            __typename: 'Event',
+            id: '1369200957569262',
+            name: 'Bachata & Salsa: FREE Open Class + Party',
+            is_canceled: false,
+            event_creator: {
+              __typename: 'User',
+              __isEntity: 'User',
+              url: 'https://www.facebook.com/welovesalsa.cz',
+              name: 'WE LOVE SALSA & BACHATA PRAGUE',
+              id: '100065523248074'
+            },
+            event_place: {
+              __typename: 'FreeformPlace',
+              contextual_name: 'FU Club & Lounge',
+              // location: [Object],
+              __isNode: 'FreeformPlace',
+              id: '1006118838248882'
+            },
+            day_time_sentence: 'Tue, Mar 25',
+            url: 'https://www.facebook.com/events/1369200957569262/',
+            gif_cover_photo: null,
+            cover_video: null,
+            __isEntity: 'Event'
+          },
+          image: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/487046954_1026604226200343_5393607080423385390_n.jpg?stp=c131.0.1160.800a_dst-jpg_s235x165_tt6&_nc_cat=100&ccb=1-7&_nc_sid=4bdd9b&_nc_ohc=-6cOgj804WIQ7kNvgHHe3sh&_nc_oc=Adnv6N2ofEbZYi_EOE8PYtPCXysp4ZrY-9sRrbh0m10mcX9UXEIG-bnWTSu6tcE5I-gmQn-Hj6CFtCnE1BOEnS6e&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=i0OmDEnQ8J0UdVYn5UVEGw&oh=00_AYEYHs2eNkfjQlffiH53tEo0mvz7XAHUwHxEdGyaR16QNg&oe=67F4373C'
+          },
+          url: 'https://www.facebook.com/events/1369200957569262/',
+          actions_renderer: {
+            __typename: 'TimelineAppCollectionItemEventsListActionsRenderer',
+            event: {
+              id: '1369200957569262',
+              eventUrl: 'https://www.facebook.com/events/1369200957569262/',
+              can_page_viewer_invite_as_user: false,
+              can_viewer_invite: false,
+              can_viewer_rsvp: false,
+              can_viewer_share: true,
+              event_kind: 'PUBLIC_TYPE',
+              if_viewer_can_duplicate_event: null,
+              is_happening_now: false,
+              is_online_or_detected_online: false,
+              is_past: true,
+              is_viewer_host: false,
+              start_timestamp: 1742929200,
+              // rsvp_button_renderer: [Object],
+              online_event_setup: null,
+              // parent_if_exists_or_self: [Object],
+              live_virtual_event_info: null
+            },
+            __module_operation_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer_actionsRenderer$normalization.graphql'
+              },
+            __module_component_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer.react'
+              }
+          },
+          privacy_scope: null,
+          __typename: 'TimelineAppCollectionItem'
+        },
+        cursor:
+          'AQHRMn0PrMDjXcV6Z_ZnmAlKUozqe2pV2T0CHyw3g2H_o4CnDsOpnrnP03aJ9DuXxyHfm_iZzy8z8r9opIxgyIQ1Yg'
+      },
+      {
+        node: {
+          id: 'YXBwX2l0ZW06MTAwMDQ0NDUyNzkzOTIwOjIzNDQwNjEwMzM6MjEwOjo5OTg0OTE1MTIyMjg2NjU=',
+          node: {
+            __typename: 'Event',
+            id: '998491512228665',
+            name: 'Bachata & Salsa: FREE Open Class + Party',
+            is_canceled: false,
+            event_creator: {
+              __typename: 'User',
+              __isEntity: 'User',
+              url: 'https://www.facebook.com/welovesalsa.cz',
+              name: 'WE LOVE SALSA & BACHATA PRAGUE',
+              id: '100065523248074'
+            },
+            event_place: {
+              __typename: 'FreeformPlace',
+              contextual_name: 'FU Club & Lounge',
+              // location: [Object],
+              __isNode: 'FreeformPlace',
+              id: '1017903503737082'
+            },
+            day_time_sentence: 'Tue, Mar 18',
+            url: 'https://www.facebook.com/events/998491512228665/',
+            gif_cover_photo: null,
+            cover_video: null,
+            __isEntity: 'Event'
+          },
+          image: {
+            uri: 'https://scontent.fprg1-1.fna.fbcdn.net/v/t39.30808-6/487365867_1026603899533709_1191975961834505807_n.jpg?stp=c184.0.1160.800a_dst-jpg_s235x165_tt6&_nc_cat=111&ccb=1-7&_nc_sid=4bdd9b&_nc_ohc=pxWq0UEr5jkQ7kNvgF43RpO&_nc_oc=AdmUyDVXFHn9QDhE6vcBjOB298AKnSuR_C4Z8cNfDnxPFODtSw_lTY0muj6FKUPSiq6CwHvkuhUR1MVrW-lRJIOG&_nc_zt=23&_nc_ht=scontent.fprg1-1.fna&_nc_gid=yLL1WhuniHq6LKPJWWonMg&oh=00_AYHkS8TDuPp7wEursOJANebdjagLHyrx7IjDt6nyeTQrHQ&oe=67F45739'
+          },
+          url: 'https://www.facebook.com/events/998491512228665/',
+          actions_renderer: {
+            __typename: 'TimelineAppCollectionItemEventsListActionsRenderer',
+            event: {
+              id: '998491512228665',
+              eventUrl: 'https://www.facebook.com/events/998491512228665/',
+              can_page_viewer_invite_as_user: false,
+              can_viewer_invite: false,
+              can_viewer_rsvp: false,
+              can_viewer_share: true,
+              event_kind: 'PUBLIC_TYPE',
+              if_viewer_can_duplicate_event: null,
+              is_happening_now: false,
+              is_online_or_detected_online: false,
+              is_past: true,
+              is_viewer_host: false,
+              start_timestamp: 1742324400,
+              // rsvp_button_renderer: [Object],
+              online_event_setup: null,
+              // parent_if_exists_or_self: [Object],
+              live_virtual_event_info: null
+            },
+            __module_operation_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer_actionsRenderer$normalization.graphql'
+              },
+            __module_component_ProfileCometAppCollectionEventItem_timelineAppCollectionItem:
+              {
+                __dr: 'ProfileCometAppCollectionItemEventsListActionsRenderer.react'
+              }
+          },
+          privacy_scope: null,
+          __typename: 'TimelineAppCollectionItem'
+        },
+        cursor:
+          'AQHRb9aNSelWo4Re-4ZNwnvNi5svwKyIOYxLrrz0qNtn-RCb-Mu3LV4l56UNGD9tlOdN6jLI_VD9b81ZFLR7cG2Mqw'
+      }
+    ],
+    page_info: {
+      end_cursor:
+        'AQHR-6LZ8llndAOu_VD_tffNkvzMm_dcfQepO1FmhRiiK3bejQPLaCwM0GCj88ws9C5q3Tzp5QxV2cqbnGUkWgYmVA',
+      has_next_page: true
+    }
+  }
+};
+
+export const eventListPageEmptyData = {
+  name: 'Past',
+  id: 'YXBwX2NvbGxlY3Rpb246MTAwMDQ0NDUyNzkzOTIwOjIzNDQwNjEwMzM6MjEw',
+  items: { count: 0 },
+  pageItems: {
+    edges: [],
+    page_info: {
+      end_cursor:
+        'AQHR-6LZ8llndAOu_VD_tffNkvzMm_dcfQepO1FmhRiiK3bejQPLaCwM0GCj88ws9C5q3Tzp5QxV2cqbnGUkWgYmVA',
+      has_next_page: false
+    }
+  }
+};

--- a/src/utils/tests/eventListParser.test.ts
+++ b/src/utils/tests/eventListParser.test.ts
@@ -9,7 +9,7 @@ import {
   eventListGroupData,
   eventListGroupEmptyData
 } from './data/eventListGroupData';
-import { EventType } from '../../types';
+import { EventType } from '../../enums';
 
 const findJsonInStringSpy = jest.spyOn(jsonUtil, 'findJsonInString');
 
@@ -25,10 +25,10 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('getEventListFromPage', () => {
+describe('getEventListFromPageOrProfile', () => {
   it('should return basic data', () => {
     mockJsonReturnData(eventListPageData);
-    const result = eventListParser.getEventListFromPage('some html');
+    const result = eventListParser.getEventListFromPageOrProfile('some html');
 
     expect(findJsonInStringSpy).toHaveBeenCalledWith('some html', 'collection');
     expect(result).toEqual([
@@ -61,7 +61,7 @@ describe('getEventListFromPage', () => {
 
   it('should return empty list', () => {
     mockJsonReturnData(eventListPageEmptyData);
-    const result = eventListParser.getEventListFromPage('some html');
+    const result = eventListParser.getEventListFromPageOrProfile('some html');
 
     expect(findJsonInStringSpy).toHaveBeenCalledWith('some html', 'collection');
     expect(result).toEqual([]);

--- a/src/utils/tests/eventListParser.test.ts
+++ b/src/utils/tests/eventListParser.test.ts
@@ -1,0 +1,178 @@
+import * as jsonUtil from '../json';
+import * as htmlParser from '../htmlParser';
+import * as eventListParser from '../eventListParser';
+import {
+  eventListPageData,
+  eventListPageEmptyData
+} from './data/eventListPageData';
+import {
+  eventListGroupData,
+  eventListGroupEmptyData
+} from './data/eventListGroupData';
+import { EventType } from '../../types';
+
+const findJsonInStringSpy = jest.spyOn(jsonUtil, 'findJsonInString');
+
+function mockJsonReturnData(jsonData: any, startIndex = 0, endIndex = 10) {
+  findJsonInStringSpy.mockReturnValueOnce({
+    jsonData,
+    startIndex,
+    endIndex
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getEventListFromPage', () => {
+  it('should return basic data', () => {
+    mockJsonReturnData(eventListPageData);
+    const result = eventListParser.getEventListFromPage('some html');
+
+    expect(findJsonInStringSpy).toHaveBeenCalledWith('some html', 'collection');
+    expect(result).toEqual([
+      {
+        id: '1372327683701218',
+        name: 'Bachata & Salsa: FREE Open Class + Party',
+        url: 'https://www.facebook.com/events/1372327683701218/',
+        date: 'Tue, Apr 1',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '1369200957569262',
+        name: 'Bachata & Salsa: FREE Open Class + Party',
+        url: 'https://www.facebook.com/events/1369200957569262/',
+        date: 'Tue, Mar 25',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '998491512228665',
+        name: 'Bachata & Salsa: FREE Open Class + Party',
+        url: 'https://www.facebook.com/events/998491512228665/',
+        date: 'Tue, Mar 18',
+        isCanceled: false,
+        isPast: true
+      }
+    ]);
+  });
+
+  it('should return empty list', () => {
+    mockJsonReturnData(eventListPageEmptyData);
+    const result = eventListParser.getEventListFromPage('some html');
+
+    expect(findJsonInStringSpy).toHaveBeenCalledWith('some html', 'collection');
+    expect(result).toEqual([]);
+  });
+
+  it('should throw an error if no basic event data is found', () => {
+    mockJsonReturnData(null);
+    expect(() => htmlParser.getBasicData('some html')).toThrow(
+      new Error(
+        'No event data found, please verify that your URL is correct and the event is accessible without authentication'
+      )
+    );
+  });
+});
+
+describe('getEventListFromGroup', () => {
+  it('should return basic upcoming data', () => {
+    mockJsonReturnData(eventListGroupData);
+    const result = eventListParser.getEventListFromGroup(
+      'some html',
+      EventType.Upcoming
+    );
+
+    expect(findJsonInStringSpy).toHaveBeenCalledWith(
+      'some html',
+      'upcoming_events'
+    );
+    expect(result).toEqual([
+      {
+        id: '916236709985575',
+        name: 'NEW YEAR EVE 2025',
+        url: 'https://www.facebook.com/events/916236709985575/',
+        date: 'Tue, Dec 31, 2024',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '591932410074832',
+        name: 'REGGAETON NIGHT',
+        url: 'https://www.facebook.com/events/591932410074832/',
+        date: 'Fri, Nov 22, 2024',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '1103230308135807',
+        name: 'FIESTA LATINA',
+        url: 'https://www.facebook.com/events/1103230308135807/',
+        date: 'Sat, Nov 9, 2024',
+        isCanceled: false,
+        isPast: true
+      }
+    ]);
+  });
+
+  it('should return basic upcoming data', () => {
+    mockJsonReturnData(eventListGroupData);
+    const result = eventListParser.getEventListFromGroup(
+      'some html',
+      EventType.Past
+    );
+
+    expect(findJsonInStringSpy).toHaveBeenCalledWith(
+      'some html',
+      'past_events'
+    );
+    expect(result).toEqual([
+      {
+        id: '916236709985575',
+        name: 'NEW YEAR EVE 2025',
+        url: 'https://www.facebook.com/events/916236709985575/',
+        date: 'Tue, Dec 31, 2024',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '591932410074832',
+        name: 'REGGAETON NIGHT',
+        url: 'https://www.facebook.com/events/591932410074832/',
+        date: 'Fri, Nov 22, 2024',
+        isCanceled: false,
+        isPast: true
+      },
+      {
+        id: '1103230308135807',
+        name: 'FIESTA LATINA',
+        url: 'https://www.facebook.com/events/1103230308135807/',
+        date: 'Sat, Nov 9, 2024',
+        isCanceled: false,
+        isPast: true
+      }
+    ]);
+  });
+
+  it('should return empty list', () => {
+    mockJsonReturnData(eventListGroupEmptyData);
+    const result = eventListParser.getEventListFromGroup('some html');
+
+    expect(findJsonInStringSpy).toHaveBeenCalledWith(
+      'some html',
+      'upcoming_events'
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('should throw an error if no basic event data is found', () => {
+    mockJsonReturnData(null);
+    expect(() => htmlParser.getBasicData('some html')).toThrow(
+      new Error(
+        'No event data found, please verify that your URL is correct and the event is accessible without authentication'
+      )
+    );
+  });
+});

--- a/src/utils/tests/url.test.ts
+++ b/src/utils/tests/url.test.ts
@@ -1,4 +1,10 @@
-import { fbidToUrl, validateAndFormatUrl } from '../url';
+import {
+  fbidToUrl,
+  validateAndFormatEventGroupUrl,
+  validateAndFormatEventPageUrl,
+  validateAndFormatUrl
+} from '../url';
+import { EventType } from '../../enums';
 
 describe('fbidToUrl', () => {
   it('returns the correct URL for a valid FB ID', () => {
@@ -57,5 +63,229 @@ describe('validateAndFormatUrl', () => {
     expect(() =>
       validateAndFormatUrl('https://www.facebook.com/invalid-url')
     ).toThrow('Invalid Facebook event URL');
+  });
+});
+
+describe('validateAndFormatEventPageUrl without type parameter', () => {
+  it('returns the correct URL for a valid FB event page URL', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with upcoming events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with past events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB page URL', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/events?_fb_noscript=1'
+    );
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/some-events'
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events/something-else'
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL with some parameters', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events?something=testing'
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+});
+
+describe('validateAndFormatEventPageUrl with type parameter', () => {
+  it('returns the correct URL for a valid FB event page URL transformed to past events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL transformed to upcoming events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with upcoming events transformed to past events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with upcoming events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with past events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event page URL with past events events transformed to upcoming events', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB page URL with Past type', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/past_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct URL for a valid FB page URL with Upcoming type', () => {
+    const result = validateAndFormatEventPageUrl(
+      'https://www.facebook.com/lacalle8prague',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/lacalle8prague/upcoming_hosted_events?_fb_noscript=1'
+    );
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/some-events',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events/something-else',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL with some parameters', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events?something=testing',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL when you use FB group page', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/groups/409785992417637/events',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+});
+
+describe('validateAndFormatEventGroupUrl', () => {
+  it('returns the correct URL for a valid FB event group URL', () => {
+    const result = validateAndFormatEventGroupUrl(
+      'https://www.facebook.com/groups/409785992417637/events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/groups/409785992417637/events?_fb_noscript=1'
+    );
+  });
+
+  it('returns the correct event group URL for a valid FB group URL', () => {
+    const result = validateAndFormatEventGroupUrl(
+      'https://www.facebook.com/groups/409785992417637'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/groups/409785992417637/events?_fb_noscript=1'
+    );
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/group/some-events'
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events/something-else'
+      )
+    ).toThrow('Invalid Facebook page event URL');
+  });
+
+  it('throws an error for an invalid FB event page URL with some parameters', () => {
+    expect(() =>
+      validateAndFormatEventPageUrl(
+        'https://www.facebook.com/lacalle8prague/events?something=testing'
+      )
+    ).toThrow('Invalid Facebook page event URL');
   });
 });

--- a/src/utils/tests/url.test.ts
+++ b/src/utils/tests/url.test.ts
@@ -2,6 +2,7 @@ import {
   fbidToUrl,
   validateAndFormatEventGroupUrl,
   validateAndFormatEventPageUrl,
+  validateAndFormatEventProfileUrl,
   validateAndFormatUrl
 } from '../url';
 import { EventType } from '../../enums';
@@ -287,5 +288,185 @@ describe('validateAndFormatEventGroupUrl', () => {
         'https://www.facebook.com/lacalle8prague/events?something=testing'
       )
     ).toThrow('Invalid Facebook page event URL');
+  });
+});
+
+describe('validateAndFormatEventProfileUrl without type parameter', () => {
+  it('returns the correct URL for a valid FB event profile URL', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with upcoming events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with past events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB profile URL', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125'
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events'
+    );
+  });
+
+  it('throws an error for an invalid FB event profile URL', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/profile.php?id=61553164865125&sk=some-events'
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+
+  it('throws an error for an invalid FB event profile URL', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/lacalle8prague/events/something-else'
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+
+  it('throws an error for an invalid FB event profile URL with some parameters', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/profile.php?something=testing'
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+});
+
+describe('validateAndFormatEventProfileUrl with type parameter', () => {
+  it('returns the correct URL for a valid FB event profile URL transformed to past events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL transformed to upcoming events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with upcoming events transformed to past events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with upcoming events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with past events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB event profile URL with past events events transformed to upcoming events', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB profile URL with Past type', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125',
+      EventType.Past
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=past_hosted_events'
+    );
+  });
+
+  it('returns the correct URL for a valid FB profile URL with Upcoming type', () => {
+    const result = validateAndFormatEventProfileUrl(
+      'https://www.facebook.com/profile.php?id=61553164865125',
+      EventType.Upcoming
+    );
+    expect(result).toEqual(
+      'https://www.facebook.com/profile.php?id=61553164865125&sk=upcoming_hosted_events'
+    );
+  });
+
+  it('throws an error for an invalid FB event profile URL', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/profile.php?id=61553164865125&sk=some-events',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+
+  it('throws an error for an invalid FB event profile URL', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/profile.php?id=61553164865125&sk=something-else',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+
+  it('throws an error for an invalid FB event profile URL with some parameters', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/profile.php?something=testing',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook profile event URL');
+  });
+
+  it('throws an error for an invalid FB event profile URL when you use FB group page', () => {
+    expect(() =>
+      validateAndFormatEventProfileUrl(
+        'https://www.facebook.com/groups/409785992417637/events',
+        EventType.Past
+      )
+    ).toThrow('Invalid Facebook profile event URL');
   });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -59,6 +59,41 @@ export const validateAndFormatEventPageUrl = (
 };
 
 // Covers pages with the following format:
+// https://www.facebook.com/profile.php?id=61553164865125&sk=events
+// https://www.facebook.com/profile.php?id=61564982700539
+// https://www.facebook.com/profile.php?id=61564982700539&sk=past_hosted_events
+// https://www.facebook.com/profile.php?id=61564982700539&sk=upcoming_hosted_events
+export const validateAndFormatEventProfileUrl = (
+  url: string,
+  type?: EventType
+) => {
+  const regex =
+    /facebook\.com\/profile\.php\?id=\d+(&sk=(events|past_hosted_events|upcoming_hosted_events))?$/;
+  const result = regex.test(url);
+
+  if (!result) {
+    throw new Error('Invalid Facebook profile event URL');
+  }
+
+  const types = /(past_hosted_events|upcoming_hosted_events|events)$/;
+  if (!types.test(url)) {
+    if (type === EventType.Past) {
+      url += '&sk=past_hosted_events';
+    } else if (type === EventType.Upcoming) {
+      url += '&sk=upcoming_hosted_events';
+    } else {
+      url += '&sk=events';
+    }
+  } else if (type === EventType.Past) {
+    url = url.replace(types, 'past_hosted_events');
+  } else if (type === EventType.Upcoming) {
+    url = url.replace(types, 'upcoming_hosted_events');
+  }
+
+  return url;
+};
+
+// Covers pages with the following format:
 // https://www.facebook.com/groups/409785992417637/events
 // https://www.facebook.com/groups/409785992417637
 export const validateAndFormatEventGroupUrl = (url: string) => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,5 @@
+import { EventType } from '../enums';
+
 export const fbidToUrl = (fbid: string) => {
   if (!fbid.match(/^[0-9]{8,}$/)) {
     throw new Error('Invalid FB ID');
@@ -20,4 +22,56 @@ export const validateAndFormatUrl = (url: string) => {
   }
 
   return `https://www.facebook.com/events/${fbid}?_fb_noscript=1`;
+};
+
+// Covers pages with the following format:
+// https://www.facebook.com/lacalle8prague/past_hosted_events
+// https://www.facebook.com/lacalle8prague/upcoming_hosted_events
+// https://www.facebook.com/lacalle8prague/events
+export const validateAndFormatEventPageUrl = (
+  url: string,
+  type?: EventType
+) => {
+  const regex =
+    /facebook\.com\/[a-zA-Z0-9]+(?:\/(past_hosted_events|upcoming_hosted_events|events))?$/;
+  const result = regex.test(url);
+
+  if (!result) {
+    throw new Error('Invalid Facebook page event URL');
+  }
+
+  const types = /(past_hosted_events|upcoming_hosted_events|events)$/;
+  if (!types.test(url)) {
+    if (type === EventType.Past) {
+      url += '/past_hosted_events';
+    } else if (type === EventType.Upcoming) {
+      url += '/upcoming_hosted_events';
+    } else {
+      url += '/events';
+    }
+  } else if (type === EventType.Past) {
+      url = url.replace(types, 'past_hosted_events');
+    } else if (type === EventType.Upcoming) {
+      url = url.replace(types, 'upcoming_hosted_events');
+    }
+
+  return `${url}?_fb_noscript=1`;
+};
+
+// Covers pages with the following format:
+// https://www.facebook.com/groups/409785992417637/events
+// https://www.facebook.com/groups/409785992417637
+export const validateAndFormatEventGroupUrl = (url: string) => {
+  const regex = /facebook\.com\/groups\/\d+(?:\/events$)?/;
+  const result = regex.test(url);
+
+  if (!result) {
+    throw new Error('Invalid Facebook group event URL');
+  }
+
+  if (!url.match('/events')) {
+    url += '/events';
+  }
+
+  return `${url}?_fb_noscript=1`;
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -50,10 +50,10 @@ export const validateAndFormatEventPageUrl = (
       url += '/events';
     }
   } else if (type === EventType.Past) {
-      url = url.replace(types, 'past_hosted_events');
-    } else if (type === EventType.Upcoming) {
-      url = url.replace(types, 'upcoming_hosted_events');
-    }
+    url = url.replace(types, 'past_hosted_events');
+  } else if (type === EventType.Upcoming) {
+    url = url.replace(types, 'upcoming_hosted_events');
+  }
 
   return `${url}?_fb_noscript=1`;
 };


### PR DESCRIPTION
Hello, I need to parse list of events from FB page and groups so I added two other functions:
scrapeFbEventListFromPage(url, EventType)
scrapeFbEventListFromGroup(url, EventType)

EventType describes whether an event is upcoming or has already passed.

I added example into README.md and also some tests for url validators and parser.

TypeScript isn’t my daily language, so I hope the syntax is good. 
Let me know if everything looks right! ;)

This PR fix issue: https://github.com/francescov1/facebook-event-scraper/issues/24